### PR TITLE
Add get_eco_climate tool: CO2, sea level, polluter attribution, Earth anchor

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -20,12 +20,14 @@ Defined in [src/eco_mcp_app/server.py](../src/eco_mcp_app/server.py). All tools 
 - **fair_price** - Real-world commodity price advisor backed by FRED (copper, wheat, lumber, iron, crude oil). Percent-change at 7d/30d/90d cadences.
 - **get_eco_ecoregion** - Biome classification against WWF ecoregions. Donut chart, top-3 matches, per-species boom/bust lists.
 - **get_eco_government** - Civic org chart. Elected titles plus occupants, active elections with countdown, active laws (markup stripped).
+- **get_eco_climate** - Atmospheric visibility for non-industrial players. Live CO2 ppm, sea-level height + projected drift rate, ground-pollution percentage, real-world Earth CO2 anchor (NOAA Mauna Loa), and a top-polluting-citizens / -stations leaderboard sourced from the action exporter. Tolerant to dataset-name drift across Eco versions: probes a candidate list and uses whichever the server exposes.
 - **list_public_eco_servers** - Curated roster of 6 known public servers with labels, host:port, notes.
 
 ## MCP resources
 
 - **ui://eco/status.html** - Main iframe shell. Initial resource and Jinja2 template for per-tool card fragments.
 - **ui://eco/economy.html** - Economy dashboard shell. Same transport pattern.
+- **ui://eco/climate.html** - Climate / atmosphere dashboard shell. Same transport pattern.
 
 ## Runtime surfaces
 
@@ -84,7 +86,7 @@ Defined in [src/eco_mcp_app/server.py](../src/eco_mcp_app/server.py). All tools 
 ## Dev tooling
 
 - **Task runner** - pyinvoke. [tasks.py](../tasks.py).
-  - `inv smoke` - Stdio end-to-end test exercising all 11 tools.
+  - `inv smoke` - Stdio end-to-end test exercising all 12 tools.
   - `inv http` - Local HTTP transport on port 4000 with hot reload.
   - `inv harness` - Browser dev harness at `localhost:8765/static/harness.html`. Mimics MCP Apps host with mocked tool-result payloads.
   - `inv test` - pytest.
@@ -103,7 +105,7 @@ Defined in [src/eco_mcp_app/server.py](../src/eco_mcp_app/server.py). All tools 
 
 ## Scope at a glance
 
-- 11 MCP tools
+- 12 MCP tools
 - 2 MCP resources
 - 6 external data sources (3 Eco endpoints, Wikidata, FRED, iNaturalist)
 - 3 bundled data assets (~20MB)

--- a/src/eco_mcp_app/climate.py
+++ b/src/eco_mcp_app/climate.py
@@ -1,0 +1,715 @@
+"""Climate / atmosphere visibility — CO2 ppm, sea level, ground pollution.
+
+Players who don't run polluting machines can't see the global atmospheric
+state until it bites them (sea-level inundation, eco-collapse). This module
+surfaces that data through MCP so any player can query the trend before
+they're affected.
+
+Three independent slices, each tolerant to absence — empty data is a valid
+state, not an error:
+
+1. **Time-series via ``/datasets/get``** — CO2 ppm, sea-level height, average
+   ground pollution. Eco's stat catalog has shifted across versions and mods
+   can register their own, so we try a list of candidate dataset names and
+   use whichever returns data. Same fan-out + 200/500-tolerant pattern as
+   ``server.fetch_economy``.
+
+2. **Polluter attribution via ``/api/v1/exporter/actions``** — same stream-
+   parse approach as ``crafting.py``. Tries several action-name candidates
+   so the card stays useful regardless of which actions a given Eco version
+   emits. Aggregates emitted-pollution count by citizen and station.
+
+3. **Worldlayers ``Summary`` text** — for a headline ground-pollution
+   percentage when no ``/datasets`` series exists. Same endpoint that
+   ``ecoregion.py`` already hits.
+
+Real-world Earth CO2 anchor: bundled NOAA Mauna Loa annual averages so the
+card can say "412 ppm — Earth crossed that in 2019." Public-domain values
+trimmed to ~10 inflection points so the bundle stays small.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import os
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from cachetools import TTLCache
+
+# Candidate dataset names. We try each in order and use the first that
+# returns at least one point. An empty result simply means the server
+# doesn't expose that name — not an error. Order is "most-likely first"
+# based on Eco's published stat catalog and common modded names.
+CO2_DATASET_CANDIDATES: tuple[str, ...] = (
+    "CO2PPM",
+    "AverageCO2PPM",
+    "AtmosphereCO2",
+    "CO2",
+)
+SEA_LEVEL_DATASET_CANDIDATES: tuple[str, ...] = (
+    "SeaLevel",
+    "SeaLevelHeight",
+    "OceanLevel",
+)
+POLLUTION_DATASET_CANDIDATES: tuple[str, ...] = (
+    "GroundPollution",
+    "AveragePollution",
+    "Pollution",
+)
+
+# Action names for polluter attribution. Same defensive multi-name approach
+# — the exporter returns 404 / empty for unknown names, which we silently skip.
+POLLUTION_ACTION_TYPES: tuple[str, ...] = (
+    "PollutionAction",
+    "EmitPollutionAction",
+    "EmitCO2Action",
+    "BurnFuelAction",
+)
+
+# Real-world Mauna Loa annual mean CO2, ppm. NOAA, public domain, 2024 update:
+# https://gml.noaa.gov/ccgg/trends/. Trimmed to inflection points so the
+# anchor is meaningful without bloating the module.
+EARTH_CO2_HISTORY: tuple[tuple[int, float], ...] = (
+    (1750, 277.0),
+    (1850, 285.0),
+    (1900, 296.0),
+    (1958, 315.0),
+    (1980, 339.0),
+    (1990, 354.0),
+    (2000, 369.0),
+    (2010, 389.0),
+    (2015, 401.0),
+    (2020, 414.0),
+    (2024, 422.0),
+)
+
+# Pre-industrial baseline for the warming-status heuristic. Anything above
+# 350 ppm is "warming"; >500 ppm tips into "critical" because Eco's default
+# Sea Level Rise mod starts triggering above that threshold.
+_PREINDUSTRIAL_PPM = 280.0
+_WARMING_PPM = 350.0
+_CRITICAL_PPM = 500.0
+
+# Per-process cache. Climate moves slowly (one tick every game hour) so a 60s
+# TTL is plenty and prevents the iframe-on-refresh case from hammering the
+# admin endpoint.
+_CACHE_TTL_S = float(os.environ.get("ECO_CLIMATE_CACHE_TTL", "60"))
+_climate_cache: TTLCache[str, "ClimateSnapshot"] = TTLCache(maxsize=64, ttl=_CACHE_TTL_S)
+
+# Action exporter row cap — same defensive bound as crafting.py uses.
+_MAX_ROWS_PER_ACTION = int(os.environ.get("ECO_CLIMATE_MAX_ROWS", "200000"))
+
+
+@dataclass
+class ClimateSnapshot:
+    """Raw fetch result. JSON-serializable via :meth:`to_dict`."""
+
+    fetched_at_iso: str
+    source_base_url: str
+    info: dict[str, Any]
+    days_elapsed: int
+    admin_ok: bool
+    co2_series: list[tuple[float, float]] = field(default_factory=list)
+    sea_level_series: list[tuple[float, float]] = field(default_factory=list)
+    pollution_series: list[tuple[float, float]] = field(default_factory=list)
+    co2_dataset_name: str | None = None
+    sea_level_dataset_name: str | None = None
+    pollution_dataset_name: str | None = None
+    # Worldlayers fallback for ground-pollution headline (e.g. "4%").
+    pollution_layer_summary: str | None = None
+    # Polluter attribution. Sorted descending by emission count.
+    top_polluter_citizens: list[tuple[str, float]] = field(default_factory=list)
+    top_polluter_stations: list[tuple[str, float]] = field(default_factory=list)
+    pollution_actions_total: int = 0
+    pollution_action_types_seen: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fetchedAtISO": self.fetched_at_iso,
+            "sourceBaseUrl": self.source_base_url,
+            "daysElapsed": self.days_elapsed,
+            "adminOk": self.admin_ok,
+            "co2Series": [[t, v] for t, v in self.co2_series],
+            "seaLevelSeries": [[t, v] for t, v in self.sea_level_series],
+            "pollutionSeries": [[t, v] for t, v in self.pollution_series],
+            "co2DatasetName": self.co2_dataset_name,
+            "seaLevelDatasetName": self.sea_level_dataset_name,
+            "pollutionDatasetName": self.pollution_dataset_name,
+            "pollutionLayerSummary": self.pollution_layer_summary,
+            "topPolluterCitizens": [[n, c] for n, c in self.top_polluter_citizens],
+            "topPolluterStations": [[n, c] for n, c in self.top_polluter_stations],
+            "pollutionActionsTotal": self.pollution_actions_total,
+            "pollutionActionTypesSeen": list(self.pollution_action_types_seen),
+            "warnings": list(self.warnings),
+        }
+
+
+def _admin_base(server: str | None, default_base: str) -> str:
+    """Resolve a user-supplied server hint to an admin base URL.
+
+    Same accepted shapes as the rest of the toolset: bare host, host:port,
+    full URL, or ``None`` to use the configured default.
+    """
+    if not server:
+        return default_base.rstrip("/")
+    s = server.strip()
+    if not s:
+        return default_base.rstrip("/")
+    if "://" not in s:
+        s = f"http://{s}"
+    parsed = urlparse(s)
+    host = parsed.hostname or ""
+    port = parsed.port or 3001
+    return f"{parsed.scheme or 'http'}://{host}:{port}".rstrip("/")
+
+
+async def _fetch_dataset(
+    client: httpx.AsyncClient,
+    base: str,
+    name: str,
+    day_end: int,
+    headers: dict[str, str],
+) -> list[tuple[float, float]]:
+    """GET ``/datasets/get`` for one series. Returns ``[]`` on any non-200.
+
+    Mirrors ``server._fetch_dataset`` — duplicated rather than imported to
+    keep this module free of a server.py dependency (server.py imports here
+    via the call_tool path).
+    """
+    try:
+        r = await client.get(
+            f"{base}/datasets/get",
+            params={"dataset": name, "dayStart": 0, "dayEnd": max(day_end, 1)},
+            headers=headers,
+        )
+        if r.status_code != 200:
+            return []
+        data = r.json()
+    except (httpx.HTTPError, ValueError):
+        return []
+    out: list[tuple[float, float]] = []
+    if isinstance(data, list):
+        for pt in data:
+            if isinstance(pt, dict):
+                t = pt.get("Time", pt.get("time"))
+                v = pt.get("Value", pt.get("value"))
+            elif isinstance(pt, list | tuple) and len(pt) >= 2:
+                t, v = pt[0], pt[1]
+            else:
+                continue
+            try:
+                out.append((float(t), float(v)))
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+async def _fetch_first_nonempty(
+    client: httpx.AsyncClient,
+    base: str,
+    candidates: tuple[str, ...],
+    day_end: int,
+    headers: dict[str, str],
+) -> tuple[str | None, list[tuple[float, float]]]:
+    """Try each candidate dataset name; return the first that has data.
+
+    Probes are issued sequentially because we want to *stop* on the first hit
+    rather than fan out. The catalog is small (3-4 names) and most servers
+    will hit on the first probe, so the sequential cost is minimal.
+    """
+    for name in candidates:
+        pts = await _fetch_dataset(client, base, name, day_end, headers)
+        if pts:
+            return name, pts
+    return None, []
+
+
+async def _fetch_pollution_layer_summary(
+    client: httpx.AsyncClient, base: str
+) -> str | None:
+    """Pull the ``Pollution`` layer's ``Summary`` (e.g. ``"4%"``) from worldlayers.
+
+    The worldlayers endpoint is public — no admin token needed — which is
+    why we use it as the fallback when the admin /datasets path is locked
+    down. Returns ``None`` on any structural surprise.
+    """
+    try:
+        r = await client.get(f"{base}/api/v1/worldlayers/layers")
+        if r.status_code != 200:
+            return None
+        data = r.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    if not isinstance(data, list):
+        return None
+    for cat in data:
+        if not isinstance(cat, dict):
+            continue
+        # Layer name varies: "Pollution", "GroundPollution", or a category
+        # whose `List` contains a layer with one of those names.
+        if cat.get("Category") in ("Pollution", "Atmosphere"):
+            for entry in cat.get("List") or []:
+                summary = entry.get("Summary")
+                if summary:
+                    return str(summary)
+        for entry in cat.get("List") or []:
+            name = (entry.get("LayerName") or "").lower()
+            if "pollut" in name or "co2" in name:
+                summary = entry.get("Summary")
+                if summary:
+                    return str(summary)
+    return None
+
+
+async def _stream_csv_rows(
+    client: httpx.AsyncClient, url: str, headers: dict[str, str]
+) -> AsyncIterator[list[str]]:
+    """Yield CSV rows from a streaming response. Header row is yielded too."""
+    async with client.stream("GET", url, headers=headers) as resp:
+        resp.raise_for_status()
+        pending: list[str] = []
+        async for line in resp.aiter_lines():
+            pending.append(line)
+            if len(pending) >= 256:
+                for row in csv.reader(pending):
+                    yield row
+                pending.clear()
+        if pending:
+            for row in csv.reader(pending):
+                yield row
+
+
+async def _aggregate_pollution_action(
+    client: httpx.AsyncClient,
+    base: str,
+    action_name: str,
+    headers: dict[str, str],
+    by_citizen: dict[str, float],
+    by_station: dict[str, float],
+) -> tuple[int, str | None]:
+    """Stream one action CSV and fold pollution emissions into the totals.
+
+    Returns ``(rows_consumed, warning_or_none)``. The warning string is set
+    on a non-2xx so the caller can surface it on the rendered card without
+    treating it as fatal.
+    """
+    url = f"{base}/api/v1/exporter/actions?actionName={action_name}"
+    rows_consumed = 0
+    try:
+        header: list[str] | None = None
+        col: dict[str, int] = {}
+        async for row in _stream_csv_rows(client, url, headers):
+            if header is None:
+                header = row
+                col = {name: i for i, name in enumerate(header)}
+                continue
+            if rows_consumed >= _MAX_ROWS_PER_ACTION:
+                break
+            count_s = _pick(row, col, "Count", "Amount", "Value")
+            try:
+                count = float(count_s) if count_s is not None else 1.0
+            except ValueError:
+                count = 1.0
+            citizen = _pick(row, col, "Citizen", "Player", "User") or ""
+            station = (
+                _pick(row, col, "WorldObjectItem", "Station", "Source", "Object", "ToolUsed")
+                or "(unknown)"
+            )
+            if citizen:
+                by_citizen[citizen] = by_citizen.get(citizen, 0.0) + count
+            if station:
+                by_station[station] = by_station.get(station, 0.0) + count
+            rows_consumed += 1
+        return rows_consumed, None
+    except httpx.HTTPStatusError as e:
+        return 0, f"{action_name}: HTTP {e.response.status_code}"
+    except httpx.HTTPError as e:
+        return 0, f"{action_name}: {type(e).__name__}"
+
+
+def _pick(row: list[str], col: dict[str, int], *keys: str) -> str | None:
+    """Read the first non-empty value among ``keys`` from a CSV row.
+
+    The exporter's column order shifts between Eco versions, so we key off
+    the header instead of fixed positions — same approach as ``crafting``.
+    """
+    for k in keys:
+        if k in col and col[k] < len(row):
+            v = row[col[k]].strip()
+            if v:
+                return v
+    return None
+
+
+async def fetch_climate(
+    server: str | None,
+    *,
+    info: dict[str, Any],
+    days_elapsed: int,
+    admin_token: str | None,
+    default_admin_base: str,
+) -> ClimateSnapshot:
+    """Fetch all climate slices in parallel where possible.
+
+    The caller owns ``info`` (already retrieved via ``fetch_eco_info``) — we
+    don't fetch /info ourselves because most call sites already have it. This
+    keeps the per-call request count down and matches how
+    ``ecoregion.gather_ecoregion_payload`` is shaped.
+    """
+    base = _admin_base(server, default_admin_base)
+
+    cache_key = base
+    cached = _climate_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    snapshot = ClimateSnapshot(
+        fetched_at_iso=_now_iso(),
+        source_base_url=base,
+        info=dict(info or {}),
+        days_elapsed=max(1, int(days_elapsed or 1)),
+        admin_ok=bool(admin_token),
+    )
+
+    headers = {"X-API-Key": admin_token} if admin_token else {}
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        # Public worldlayers fetch happens regardless of the admin token —
+        # this is the fallback that gives non-admins *something* to look at.
+        layer_task = asyncio.create_task(_fetch_pollution_layer_summary(client, base))
+
+        if admin_token:
+            co2_task = asyncio.create_task(
+                _fetch_first_nonempty(
+                    client, base, CO2_DATASET_CANDIDATES, snapshot.days_elapsed, headers
+                )
+            )
+            sea_task = asyncio.create_task(
+                _fetch_first_nonempty(
+                    client,
+                    base,
+                    SEA_LEVEL_DATASET_CANDIDATES,
+                    snapshot.days_elapsed,
+                    headers,
+                )
+            )
+            poll_task = asyncio.create_task(
+                _fetch_first_nonempty(
+                    client,
+                    base,
+                    POLLUTION_DATASET_CANDIDATES,
+                    snapshot.days_elapsed,
+                    headers,
+                )
+            )
+
+            (snapshot.co2_dataset_name, snapshot.co2_series) = await co2_task
+            (snapshot.sea_level_dataset_name, snapshot.sea_level_series) = await sea_task
+            (snapshot.pollution_dataset_name, snapshot.pollution_series) = await poll_task
+
+            # Polluter attribution. Sequential per-action because the exporter
+            # CSVs can be many MB late-cycle; we stream-parse each one in turn
+            # to avoid spiking memory by N parallel streams.
+            by_citizen: dict[str, float] = {}
+            by_station: dict[str, float] = {}
+            actions_seen: list[str] = []
+            for action in POLLUTION_ACTION_TYPES:
+                rows, warn = await _aggregate_pollution_action(
+                    client, base, action, headers, by_citizen, by_station
+                )
+                if rows:
+                    actions_seen.append(action)
+                    snapshot.pollution_actions_total += rows
+                if warn and "404" not in warn and "405" not in warn:
+                    # 404/405 just means "this server doesn't emit that action
+                    # type" — silent. Other failures are worth surfacing.
+                    snapshot.warnings.append(warn)
+            snapshot.pollution_action_types_seen = actions_seen
+            snapshot.top_polluter_citizens = sorted(
+                by_citizen.items(), key=lambda kv: kv[1], reverse=True
+            )[:10]
+            snapshot.top_polluter_stations = sorted(
+                by_station.items(), key=lambda kv: kv[1], reverse=True
+            )[:10]
+
+        snapshot.pollution_layer_summary = await layer_task
+
+    _climate_cache[cache_key] = snapshot
+    return snapshot
+
+
+def _now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Payload computation — server.py renders the card from this shape.
+# ---------------------------------------------------------------------------
+
+
+def _series_last(pts: list[tuple[float, float]]) -> float:
+    return float(pts[-1][1]) if pts else 0.0
+
+
+def _series_first(pts: list[tuple[float, float]]) -> float:
+    return float(pts[0][1]) if pts else 0.0
+
+
+def _percent_change(first: float, last: float) -> float | None:
+    """Percent change from first to last. ``None`` if there's no baseline."""
+    if first == 0:
+        return None
+    return round(((last - first) / first) * 100.0, 2)
+
+
+def _earth_year_for_ppm(ppm: float) -> dict[str, Any] | None:
+    """Find the closest historical Earth year for a given ppm.
+
+    Returns ``{"year": int, "ppm": float, "note": str}`` or ``None`` if the
+    in-game value is below the pre-industrial baseline (rare, but possible
+    on heavily-modded peaceful servers).
+    """
+    if ppm < EARTH_CO2_HISTORY[0][1] - 5.0:
+        return None
+    # Above the most-recent recorded year — flag as "beyond present-day Earth".
+    latest_year, latest_ppm = EARTH_CO2_HISTORY[-1]
+    if ppm >= latest_ppm:
+        return {
+            "year": latest_year,
+            "ppm": latest_ppm,
+            "note": f"beyond present-day Earth ({latest_year}: {latest_ppm:.0f} ppm)",
+        }
+    best_year, best_ppm = EARTH_CO2_HISTORY[0]
+    best_diff = abs(ppm - best_ppm)
+    for year, hist_ppm in EARTH_CO2_HISTORY:
+        diff = abs(ppm - hist_ppm)
+        if diff < best_diff:
+            best_year, best_ppm, best_diff = year, hist_ppm, diff
+    return {
+        "year": best_year,
+        "ppm": best_ppm,
+        "note": f"Earth crossed this in ~{best_year}",
+    }
+
+
+def _classify_status(ppm: float, sea_change_pct: float | None) -> str:
+    """Three-tier health classification matching the economy card's vocabulary.
+
+    Picked to align with Eco's default Sea Level Rise mod thresholds: 350 ppm
+    is the "noticeable warming" line, 500 ppm is where the mod typically
+    starts inundating coastal property.
+    """
+    if ppm >= _CRITICAL_PPM or (sea_change_pct is not None and sea_change_pct >= 5.0):
+        return "critical"
+    if ppm >= _WARMING_PPM or (sea_change_pct is not None and sea_change_pct >= 1.0):
+        return "warming"
+    return "stable"
+
+
+def _parse_layer_pct(summary: str | None) -> float | None:
+    """``"4%"`` → ``4.0``. Tolerates whitespace + missing percent sign."""
+    if not summary:
+        return None
+    s = str(summary).strip().rstrip("%").strip()
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def compute_climate_payload(snapshot: ClimateSnapshot) -> dict[str, Any]:
+    """Shape the snapshot for the Jinja card. Pure — no IO, no SVG.
+
+    Sparkline SVGs are attached by the server.py render path so we don't pull
+    the SVG renderer into this module (and circular-import on it).
+    """
+    info = snapshot.info or {}
+    days_elapsed = snapshot.days_elapsed
+
+    co2_last = _series_last(snapshot.co2_series)
+    co2_first = _series_first(snapshot.co2_series)
+    co2_change_pct = _percent_change(co2_first, co2_last) if snapshot.co2_series else None
+
+    sea_last = _series_last(snapshot.sea_level_series)
+    sea_first = _series_first(snapshot.sea_level_series)
+    sea_change_pct = (
+        _percent_change(sea_first, sea_last) if snapshot.sea_level_series else None
+    )
+    # Linear extrapolation: at the current rate, when does sea level cross +1
+    # unit? The mod reads sea level in arbitrary units, so we project the
+    # number of cycle-days, not meters — interpretation is the player's job.
+    sea_rate_per_day = (
+        (sea_last - sea_first) / max(days_elapsed, 1) if snapshot.sea_level_series else 0.0
+    )
+
+    pollution_last = _series_last(snapshot.pollution_series)
+    pollution_layer_pct = _parse_layer_pct(snapshot.pollution_layer_summary)
+    # Prefer the live series; fall back to the worldlayers summary number.
+    pollution_value: float | None
+    pollution_source: str
+    if snapshot.pollution_series:
+        pollution_value = pollution_last
+        pollution_source = snapshot.pollution_dataset_name or "series"
+    elif pollution_layer_pct is not None:
+        pollution_value = pollution_layer_pct
+        pollution_source = "worldlayers"
+    else:
+        pollution_value = None
+        pollution_source = "none"
+
+    earth_match = _earth_year_for_ppm(co2_last) if snapshot.co2_series else None
+    status = _classify_status(co2_last, sea_change_pct) if snapshot.co2_series else "unknown"
+
+    has_attribution = bool(
+        snapshot.top_polluter_citizens or snapshot.top_polluter_stations
+    )
+
+    narrative = _narrative(
+        status=status,
+        co2_ppm=co2_last,
+        co2_change_pct=co2_change_pct,
+        sea_change_pct=sea_change_pct,
+        admin_ok=snapshot.admin_ok,
+        any_series=bool(snapshot.co2_series or snapshot.sea_level_series),
+    )
+
+    return {
+        "view": "eco_climate",
+        "server": {
+            "description": info.get("Description", ""),
+            "category": info.get("Category"),
+            "sourceUrl": info.get("_sourceUrl"),
+        },
+        "days_elapsed": days_elapsed,
+        "admin_ok": snapshot.admin_ok,
+        "status": status,
+        "narrative": narrative,
+        "co2": {
+            "current": round(co2_last, 1) if snapshot.co2_series else None,
+            "change_pct": co2_change_pct,
+            "dataset_name": snapshot.co2_dataset_name,
+            "series": [list(p) for p in snapshot.co2_series],
+        },
+        "sea_level": {
+            "current": round(sea_last, 3) if snapshot.sea_level_series else None,
+            "change_pct": sea_change_pct,
+            "rate_per_day": round(sea_rate_per_day, 4),
+            "dataset_name": snapshot.sea_level_dataset_name,
+            "series": [list(p) for p in snapshot.sea_level_series],
+        },
+        "pollution": {
+            "current": (
+                round(pollution_value, 2) if pollution_value is not None else None
+            ),
+            "source": pollution_source,
+            "dataset_name": snapshot.pollution_dataset_name,
+            "layer_summary": snapshot.pollution_layer_summary,
+            "series": [list(p) for p in snapshot.pollution_series],
+        },
+        "earth_match": earth_match,
+        "attribution": {
+            "has_data": has_attribution,
+            "actions_total": snapshot.pollution_actions_total,
+            "action_types_seen": list(snapshot.pollution_action_types_seen),
+            "top_citizens": [
+                {"name": n, "count": c} for n, c in snapshot.top_polluter_citizens[:5]
+            ],
+            "top_stations": [
+                {"name": n, "count": c} for n, c in snapshot.top_polluter_stations[:5]
+            ],
+        },
+        "warnings": list(snapshot.warnings),
+        "fetched_at_iso": snapshot.fetched_at_iso,
+        "source_base_url": snapshot.source_base_url,
+    }
+
+
+def _narrative(
+    *,
+    status: str,
+    co2_ppm: float,
+    co2_change_pct: float | None,
+    sea_change_pct: float | None,
+    admin_ok: bool,
+    any_series: bool,
+) -> str:
+    """One-sentence summary for the card header."""
+    if not admin_ok and not any_series:
+        return (
+            "Admin token unavailable — showing public worldlayers data only. "
+            "CO2 and sea-level series require ECO_ADMIN_TOKEN."
+        )
+    if not any_series:
+        return "No atmospheric series exposed by this server yet."
+
+    bits: list[str] = []
+    if co2_ppm:
+        bits.append(f"CO2 at {co2_ppm:.0f} ppm")
+    if co2_change_pct is not None and abs(co2_change_pct) >= 0.1:
+        sign = "+" if co2_change_pct > 0 else ""
+        bits.append(f"{sign}{co2_change_pct:.1f}% since cycle start")
+    if sea_change_pct is not None and abs(sea_change_pct) >= 0.05:
+        sign = "+" if sea_change_pct > 0 else ""
+        bits.append(f"sea level {sign}{sea_change_pct:.2f}%")
+
+    head = f"Climate is {status}"
+    if not bits:
+        return f"{head} — no measurable change yet."
+    return f"{head} — {', '.join(bits)}."
+
+
+# ---------------------------------------------------------------------------
+# Pollution heatmap GIF — used by the optional get_eco_map overlay.
+# ---------------------------------------------------------------------------
+
+
+async def fetch_pollution_overlay_gif(
+    base_url: str, *, client: httpx.AsyncClient | None = None
+) -> bytes | None:
+    """GET ``/Layers/Pollution.gif``. Returns ``None`` on any non-200.
+
+    Eco serves world-layer rasters under ``/Layers/<Name>.gif`` alongside the
+    main ``WorldPreview.gif``. The pollution layer isn't always exposed (the
+    server config can disable individual rasters), so a 404 is normal — the
+    map card just renders without the overlay.
+    """
+    base = base_url.rstrip("/")
+    url = f"{base}/Layers/Pollution.gif"
+    owns_client = client is None
+    http = client or httpx.AsyncClient(timeout=5.0)
+    try:
+        try:
+            r = await http.get(url)
+        except httpx.HTTPError:
+            return None
+        if r.status_code != 200:
+            return None
+        return r.content
+    finally:
+        if owns_client:
+            await http.aclose()
+
+
+def _clear_cache() -> None:
+    """Test hook — drop the per-process climate cache."""
+    _climate_cache.clear()
+
+
+__all__ = [
+    "CO2_DATASET_CANDIDATES",
+    "EARTH_CO2_HISTORY",
+    "POLLUTION_ACTION_TYPES",
+    "POLLUTION_DATASET_CANDIDATES",
+    "SEA_LEVEL_DATASET_CANDIDATES",
+    "ClimateSnapshot",
+    "compute_climate_payload",
+    "fetch_climate",
+    "fetch_pollution_overlay_gif",
+]

--- a/src/eco_mcp_app/map.py
+++ b/src/eco_mcp_app/map.py
@@ -56,12 +56,16 @@ def _world_base_url(server: str | None) -> str:
 
 
 async def fetch_map_bundle(server: str | None = None) -> dict[str, Any]:
-    """Fetch the three upstream payloads in parallel.
+    """Fetch the upstream payloads needed to render the map card.
 
     Returns a dict with:
       * `dimension`: `{x, y, z}` — raw.
       * `property`: `{deed_name: [{x, y}, ...]}` — raw.
       * `preview_gif`: `bytes` of the animated GIF.
+      * `pollution_gif`: `bytes` or `None`. Eco serves world-layer rasters at
+        ``/Layers/<Name>.gif``; the pollution layer isn't always exposed (the
+        config can disable individual rasters), so 404 is normal — we just
+        omit the overlay.
       * `base_url`: the base URL used (for display).
     """
     base = _world_base_url(server)
@@ -72,10 +76,20 @@ async def fetch_map_bundle(server: str | None = None) -> dict[str, Any]:
         prop_r.raise_for_status()
         gif_r = await client.get(f"{base}/Layers/WorldPreview.gif")
         gif_r.raise_for_status()
+        # Pollution overlay — best-effort. A 404 means the server config
+        # didn't enable the raster; the map still renders without it.
+        pollution_gif: bytes | None = None
+        try:
+            pol_r = await client.get(f"{base}/Layers/Pollution.gif")
+            if pol_r.status_code == 200 and pol_r.content:
+                pollution_gif = pol_r.content
+        except httpx.HTTPError:
+            pollution_gif = None
     return {
         "dimension": dim_r.json(),
         "property": prop_r.json(),
         "preview_gif": gif_r.content,
+        "pollution_gif": pollution_gif,
         "base_url": base,
     }
 
@@ -252,12 +266,17 @@ def build_map_payload(bundle: dict[str, Any]) -> dict[str, Any]:
     owners = sorted({p["owner"] for p in polygons})
     owner_colors = {o: _owner_color(o) for o in owners}
     owner_strokes = {o: _owner_stroke(o) for o in owners}
+    pollution_bytes = bundle.get("pollution_gif")
+    pollution_data_uri = (
+        gif_to_data_uri(cast(bytes, pollution_bytes)) if pollution_bytes else None
+    )
     return {
         "view": "eco_map",
         "sourceUrl": bundle.get("base_url"),
         "worldDim": {"x": dim.get("x"), "y": dim.get("y"), "z": dim.get("z")},
         "renderSize": MAP_RENDER_SIZE,
         "gifDataUri": gif_to_data_uri(cast(bytes, bundle.get("preview_gif") or b"")),
+        "pollutionDataUri": pollution_data_uri,
         "polygons": polygons,
         "deedCount": len({p["deed"] for p in polygons}),
         "ownerCount": len(owners),

--- a/src/eco_mcp_app/server.py
+++ b/src/eco_mcp_app/server.py
@@ -36,6 +36,7 @@ from mcp.types import (
 )
 from pydantic import AnyUrl
 
+from . import climate as climate_mod
 from . import ecoregion as ecoregion_mod
 from . import fair_price as fair_price_mod
 from . import species as species_mod
@@ -1612,6 +1613,92 @@ def _render_economy_card(payload: dict[str, Any]) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# Climate / atmosphere card (CO2 + sea level + pollution + Earth anchor)
+# ---------------------------------------------------------------------------
+
+
+CLIMATE_RESOURCE_URI = "ui://eco/climate.html"
+
+
+def _attach_climate_sparklines(payload: dict[str, Any]) -> dict[str, Any]:
+    """Render inline-SVG sparklines for the three climate series.
+
+    Done in server.py rather than climate.py to avoid pulling the Markup /
+    Jinja-aware sparkline renderer into the data module — same split as the
+    economy card, where compute_economy_payload returns raw points and the
+    render path attaches SVG.
+    """
+    for slot in ("co2", "sea_level", "pollution"):
+        section = payload.get(slot) or {}
+        pts_raw = section.get("series") or []
+        pts = [(float(t), float(v)) for t, v in pts_raw if v is not None]
+        section["spark_svg"] = Markup(_sparkline_svg(pts))
+        payload[slot] = section
+    return payload
+
+
+def _render_climate_card(payload: dict[str, Any]) -> str:
+    fetched_at = datetime.now(UTC).astimezone().strftime("%H:%M:%S")
+    return _JINJA.get_template("partials/climate_card.html").render(
+        server=payload["server"],
+        days_elapsed=payload["days_elapsed"],
+        admin_ok=payload["admin_ok"],
+        status=payload["status"],
+        narrative=payload["narrative"],
+        co2=payload["co2"],
+        sea_level=payload["sea_level"],
+        pollution=payload["pollution"],
+        earth_match=payload.get("earth_match"),
+        attribution=payload["attribution"],
+        warnings=payload.get("warnings") or [],
+        fetched_at=fetched_at,
+        steam_url=STEAM_URL,
+        banner_src=_BANNER_SRC,
+    )
+
+
+def _format_climate_markdown(payload: dict[str, Any]) -> str:
+    """Plain-text fallback for hosts without the MCP Apps iframe."""
+    server = payload["server"].get("description") or payload["server"].get("category") or "Eco"
+    co2 = payload["co2"]
+    sea = payload["sea_level"]
+    poll = payload["pollution"]
+    lines = [f"**{server} — climate: {payload['status']}**", "", payload["narrative"], ""]
+    if co2.get("current") is not None:
+        delta = (
+            f" ({co2['change_pct']:+.2f}% since cycle start)"
+            if co2.get("change_pct") is not None
+            else ""
+        )
+        lines.append(f"- CO2: **{co2['current']:.1f} ppm**{delta}")
+    if sea.get("current") is not None:
+        rate = sea.get("rate_per_day")
+        rate_str = f", {rate:+.4f}/day" if rate else ""
+        lines.append(f"- Sea level: **{sea['current']:.3f}**{rate_str}")
+    if poll.get("current") is not None:
+        lines.append(f"- Ground pollution: **{poll['current']:.1f}%** ({poll['source']})")
+    earth = payload.get("earth_match")
+    if earth:
+        lines.append(f"- Real-world anchor: {earth['note']} ({earth['ppm']:.0f} ppm).")
+    attrib = payload["attribution"]
+    if attrib.get("has_data"):
+        lines.append("")
+        lines.append("**Top polluting citizens:**")
+        for entry in attrib.get("top_citizens") or []:
+            lines.append(f"- {entry['name']}: {entry['count']:.0f}")
+        if attrib.get("top_stations"):
+            lines.append("")
+            lines.append("**Top polluting stations:**")
+            for entry in attrib.get("top_stations") or []:
+                lines.append(f"- {entry['name']}: {entry['count']:.0f}")
+    if not payload["admin_ok"]:
+        lines.extend(
+            ["", "_Admin token unavailable — series + attribution data are empty._"]
+        )
+    return "\n".join(lines)
+
+
 def _format_economy_markdown(payload: dict[str, Any]) -> str:
     k = payload["kpis"]
     server = payload["server"].get("description") or payload["server"].get("category") or "Eco"
@@ -1930,6 +2017,41 @@ def build_server() -> Server:
                 **{"_meta": UI_META},
             ),
             Tool(
+                name="get_eco_climate",
+                title="Eco — climate & pollution",
+                description=(
+                    "Surface global atmospheric state for an Eco server: live "
+                    "CO2 ppm, sea-level height + projected drift, and ground-"
+                    "pollution percentage, plus a real-world Earth CO2 anchor "
+                    "(Mauna Loa). Players who don't run polluting machines "
+                    "can use this to see the trend before sea-level rise hits "
+                    "their property. When the admin API key is configured, "
+                    "the card also lists top-polluting citizens and stations "
+                    "from the action exporter. Defaults to ECO_INFO_URL; pass "
+                    "`server` for a different one."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "server": {
+                            "type": "string",
+                            "description": (
+                                "Eco server to query. Accepts a bare host or "
+                                "IP, host:port, or a full `/info` URL. Omit "
+                                "to use the configured default."
+                            ),
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+                **{
+                    "_meta": {
+                        "ui": {"resourceUri": CLIMATE_RESOURCE_URI},
+                        "ui/resourceUri": CLIMATE_RESOURCE_URI,
+                    }
+                },
+            ),
+            Tool(
                 name="get_eco_government",
                 title="Eco — government org-chart",
                 description=(
@@ -1987,11 +2109,16 @@ def build_server() -> Server:
                 name=ECONOMY_RESOURCE_URI,
                 mimeType=RESOURCE_MIME,
             ),
+            Resource(
+                uri=AnyUrl(CLIMATE_RESOURCE_URI),
+                name=CLIMATE_RESOURCE_URI,
+                mimeType=RESOURCE_MIME,
+            ),
         ]
 
     @server.read_resource()
     async def read_resource(uri: AnyUrl) -> list[ReadResourceContents]:
-        if str(uri) in (RESOURCE_URI, ECONOMY_RESOURCE_URI):
+        if str(uri) in (RESOURCE_URI, ECONOMY_RESOURCE_URI, CLIMATE_RESOURCE_URI):
             return [ReadResourceContents(content=_render_shell(), mime_type=RESOURCE_MIME)]
         raise ValueError(f"Unknown resource: {uri}")
 
@@ -2112,7 +2239,11 @@ def build_server() -> Server:
                     **{"_meta": _ui_meta(_render_error(str(e)))},
                 )
             payload = build_map_payload(bundle)
-            json_payload = {k: v for k, v in payload.items() if k != "gifDataUri"}
+            json_payload = {
+                k: v
+                for k, v in payload.items()
+                if k not in ("gifDataUri", "pollutionDataUri")
+            }
             return CallToolResult(
                 content=[
                     TextContent(type="text", text=_format_map_markdown(payload)),
@@ -2196,6 +2327,48 @@ def build_server() -> Server:
                     TextContent(type="text", text=json.dumps(gov_payload)),
                 ],
                 **{"_meta": _ui_meta(_render_government_card(gov_payload))},
+            )
+
+        if name == "get_eco_climate":
+            server_arg = arguments.get("server") if arguments else None
+            try:
+                info = await fetch_eco_info(server_arg)
+            except httpx.HTTPError as e:
+                err_payload = {"view": "error", "message": f"Could not reach Eco server: {e}"}
+                return CallToolResult(
+                    content=[
+                        TextContent(type="text", text=f"**Eco server unreachable:** {e}"),
+                        TextContent(type="text", text=json.dumps(err_payload)),
+                    ],
+                    isError=True,
+                    **{"_meta": _ui_meta(_render_error(str(e)))},
+                )
+            # /info already gives DaysRunning; fall back to TimeSinceStart for
+            # bootstrap servers that haven't ticked the daily counter yet.
+            days_elapsed = int(info.get("DaysRunning") or 0)
+            if days_elapsed <= 0:
+                tss = info.get("TimeSinceStart")
+                try:
+                    days_elapsed = max(1, int(float(tss) / 3600.0))
+                except (TypeError, ValueError):
+                    days_elapsed = 1
+            admin_token = os.environ.get("ECO_ADMIN_TOKEN") or _get_admin_token()
+            default_admin_base = DEFAULT_ECO_INFO_URL.rsplit("/info", 1)[0]
+            snapshot = await climate_mod.fetch_climate(
+                server_arg,
+                info=info,
+                days_elapsed=days_elapsed,
+                admin_token=admin_token,
+                default_admin_base=default_admin_base,
+            )
+            payload = climate_mod.compute_climate_payload(snapshot)
+            payload = _attach_climate_sparklines(payload)
+            return CallToolResult(
+                content=[
+                    TextContent(type="text", text=_format_climate_markdown(payload)),
+                    TextContent(type="text", text=json.dumps(snapshot.to_dict(), default=str)),
+                ],
+                **{"_meta": _ui_meta(_render_climate_card(payload))},
             )
 
         if name == "fair_price":

--- a/src/eco_mcp_app/templates/eco.css
+++ b/src/eco_mcp_app/templates/eco.css
@@ -351,6 +351,59 @@
     display: block; width: 100%; height: 40px; margin: 8px 0 4px;
   }
 
+  /* ---- climate card extras ---- */
+  .climate-badge.climate-stable { background: rgba(165, 209, 74, 0.2);
+    color: var(--leaf-bright); border-color: rgba(165, 209, 74, 0.45); }
+  .climate-badge.climate-stable .dot { background: var(--leaf-bright);
+    box-shadow: 0 0 6px var(--leaf-bright); }
+  .climate-badge.climate-warming { background: rgba(244, 192, 78, 0.2);
+    color: var(--sun); border-color: rgba(244, 192, 78, 0.55); }
+  .climate-badge.climate-warming .dot { background: var(--sun);
+    box-shadow: 0 0 8px var(--sun); }
+  .climate-badge.climate-critical { background: rgba(229, 143, 44, 0.22);
+    color: var(--sunset); border-color: rgba(229, 143, 44, 0.55); }
+  .climate-badge.climate-critical .dot { background: var(--sunset);
+    box-shadow: 0 0 8px var(--sunset); }
+  .climate-badge.climate-unknown { background: rgba(120, 120, 120, 0.2);
+    color: var(--fg-muted); border-color: rgba(120, 120, 120, 0.4); }
+
+  .narrative-stable { border-left: 3px solid var(--leaf-bright); }
+  .narrative-warming { border-left: 3px solid var(--sun); }
+  .narrative-critical { border-left: 3px solid var(--sunset); }
+  .narrative-unknown { border-left: 3px solid rgba(120, 120, 120, 0.6); }
+
+  .earth-anchor { color: var(--fg-muted); font-size: 12px;
+    border-top: 1px dashed rgba(165, 209, 74, 0.25); padding-top: 6px; }
+  .earth-anchor strong { color: var(--leaf-bright); }
+
+  .climate-rank { list-style: none; padding: 0; margin: 8px 0 0;
+    display: flex; flex-direction: column; gap: 4px; font-size: 13px; }
+  .climate-rank li { display: flex; justify-content: space-between;
+    gap: 12px; align-items: baseline; padding: 2px 0;
+    border-bottom: 1px dotted rgba(165, 209, 74, 0.15); }
+  .climate-rank li:last-child { border-bottom: none; }
+  .climate-rank__name { color: var(--fg);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .climate-rank__count { color: var(--leaf-bright);
+    font-family: ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+
+  /* Pollution heatmap overlay on the map card. The image is a translucent
+     red GIF rasterized server-side from the Layers/Pollution.gif endpoint;
+     mix-blend-mode keeps deed polygons visible underneath. */
+  .eco-map__pollution {
+    position: absolute; inset: 0; pointer-events: none;
+    opacity: 0.55; mix-blend-mode: multiply;
+    filter: hue-rotate(-30deg) saturate(2);
+  }
+  .eco-map__legend-pollution {
+    display: inline-flex; align-items: center; gap: 6px;
+    color: var(--sunset); font-size: 11px; margin-left: 8px;
+  }
+  .eco-map__legend-pollution::before {
+    content: ""; display: inline-block; width: 10px; height: 10px;
+    background: var(--sunset); border-radius: 2px; opacity: 0.6;
+  }
+
   /* ---- get_eco_map card ---- */
   .eco-map { padding: 18px 20px; color: var(--fg); }
   .eco-map__head { display: flex; justify-content: space-between;

--- a/src/eco_mcp_app/templates/partials/climate_card.html
+++ b/src/eco_mcp_app/templates/partials/climate_card.html
@@ -1,0 +1,162 @@
+{# Climate / atmosphere card.
+
+   Surfaces global atmospheric state — CO2 ppm, sea level, ground pollution
+   — for any player on the server, including those who don't run polluting
+   machines and would otherwise have no in-game visibility into the trend.
+
+   Layout mirrors the economy card (banner → narrative → KPI grid →
+   sparklines → polluter attribution → footer) so the visual idiom is
+   shared. Every section gracefully degrades to "no data yet" when the
+   relevant series is empty — Eco servers very early in the cycle, or
+   without the admin token, hit this path. #}
+<div class="banner-wrap">
+  <a href="{{ steam_url }}" target="_blank" rel="noopener">
+    <img src="{{ banner_src }}" alt="Eco">
+    <div class="banner-overlay">
+      <div class="banner-title">Climate &amp; pollution</div>
+      <div class="banner-sub">
+        {{ server.description or server.category or "Eco server" }}
+        · cycle day {{ days_elapsed }}
+      </div>
+    </div>
+    <span class="banner-badge climate-badge climate-{{ status }}">
+      <span class="dot"></span>{{ status }}
+    </span>
+  </a>
+</div>
+
+<div class="about narrative narrative-{{ status }}">
+  {{ narrative }}
+  {%- if earth_match %}
+  <div class="earth-anchor" style="margin-top:6px">
+    <strong>Real-world anchor:</strong> {{ earth_match.note }}
+    (Mauna Loa annual mean ~{{ '%.0f' % earth_match.ppm }} ppm).
+  </div>
+  {%- endif %}
+  {%- if not admin_ok %}
+  <div class="hint" style="margin-top:6px">
+    Admin token unavailable — showing public worldlayers data only. Set the
+    <code>ECO_ADMIN_TOKEN</code> env var or SSM
+    <code>/eco-mcp-app/api-admin-token</code> for live CO2 / sea level series
+    and polluter attribution.
+  </div>
+  {%- endif %}
+</div>
+
+<div class="grid">
+  <div class="card">
+    <div class="card-label">CO2 ppm</div>
+    <div class="card-val">
+      {% if co2.current is not none %}
+        {{ '%.0f' % co2.current }}
+      {% else %}—{% endif %}
+    </div>
+    {{ co2.spark_svg }}
+    <div class="card-sub">
+      {% if co2.change_pct is not none %}
+        {{ '%+.2f' % co2.change_pct }}% since cycle start
+      {% else %}no series yet{% endif %}
+      {%- if co2.dataset_name %} · <code>{{ co2.dataset_name }}</code>{% endif %}
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-label">Sea level</div>
+    <div class="card-val">
+      {% if sea_level.current is not none %}
+        {{ '%.3f' % sea_level.current }}
+      {% else %}—{% endif %}
+    </div>
+    {{ sea_level.spark_svg }}
+    <div class="card-sub">
+      {% if sea_level.rate_per_day %}
+        rate {{ '%+.4f' % sea_level.rate_per_day }} / day
+      {% elif sea_level.current is not none %}
+        no measurable drift
+      {% else %}no series yet{% endif %}
+      {%- if sea_level.dataset_name %} · <code>{{ sea_level.dataset_name }}</code>{% endif %}
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-label">Ground pollution</div>
+    <div class="card-val">
+      {% if pollution.current is not none %}
+        {{ '%.1f' % pollution.current }}%
+      {% else %}—{% endif %}
+    </div>
+    {{ pollution.spark_svg }}
+    <div class="card-sub">
+      source: {{ pollution.source }}
+      {%- if pollution.dataset_name %} · <code>{{ pollution.dataset_name }}</code>{% endif %}
+    </div>
+  </div>
+</div>
+
+{% if attribution.has_data %}
+<div class="grid spark-grid" style="margin-top:14px">
+  <div class="card">
+    <div class="card-label">Top polluting citizens</div>
+    <ul class="climate-rank">
+      {% for entry in attribution.top_citizens %}
+      <li>
+        <span class="climate-rank__name">{{ entry.name }}</span>
+        <span class="climate-rank__count">{{ '%.0f' % entry.count }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% if attribution.top_stations %}
+  <div class="card">
+    <div class="card-label">Top polluting stations</div>
+    <ul class="climate-rank">
+      {% for entry in attribution.top_stations %}
+      <li>
+        <span class="climate-rank__name">{{ entry.name }}</span>
+        <span class="climate-rank__count">{{ '%.0f' % entry.count }}</span>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+</div>
+<div class="hint" style="margin-top:8px">
+  Aggregated from {{ '{:,}'.format(attribution.actions_total) }} pollution event{{ '' if attribution.actions_total == 1 else 's' }}
+  across {{ attribution.action_types_seen|length }} action type{{ '' if attribution.action_types_seen|length == 1 else 's' }}.
+</div>
+{% elif admin_ok %}
+<div class="empty" style="margin-top:14px">
+  <strong style="color:var(--leaf-bright)">No polluter attribution yet</strong>
+  <div class="hint">
+    The action exporter hasn't recorded any pollution events for the action
+    names this tool probes ({{ ", ".join(["PollutionAction", "EmitPollutionAction", "EmitCO2Action", "BurnFuelAction"]) }}).
+    This is normal for low-industry servers or very early in the cycle.
+  </div>
+</div>
+{% endif %}
+
+{% if warnings %}
+<div class="hint" style="margin-top:8px">
+  Non-fatal fetch warnings:
+  {% for w in warnings %}<code>{{ w }}</code>{{ "; " if not loop.last else "" }}{% endfor %}
+</div>
+{% endif %}
+
+<div class="footer">
+  <div class="footer-meta">
+    <span>
+      Fetched {{ fetched_at }}
+      {%- if server.sourceUrl %} · <code>{{ server.sourceUrl }}</code>{% endif %}
+    </span>
+    <div class="footer-actions">
+      <a class="cta steam" href="{{ steam_url }}" target="_blank" rel="noopener">Eco on Steam ↗</a>
+    </div>
+  </div>
+  <div class="credits-line">
+    <span>Built by <a href="https://www.coilysiren.me/" target="_blank" rel="noopener">Kai Siren</a></span>
+    <span class="sep">·</span>
+    <a href="https://github.com/coilysiren/eco-mcp-app" target="_blank" rel="noopener">source on GitHub ↗</a>
+    <span class="sep">·</span>
+    <span>Eco is &copy; <a href="https://www.strangeloopgames.com/" target="_blank" rel="noopener">StrangeLoopGames</a> — unofficial fan tool</span>
+  </div>
+</div>

--- a/src/eco_mcp_app/templates/partials/map.html
+++ b/src/eco_mcp_app/templates/partials/map.html
@@ -24,6 +24,12 @@
          src="{{ gifDataUri }}"
          alt="Eco world preview"
          width="{{ renderSize }}" height="{{ renderSize }}">
+    {% if pollutionDataUri %}
+    <img class="eco-map__pollution"
+         src="{{ pollutionDataUri }}"
+         alt="Ground pollution heatmap"
+         width="{{ renderSize }}" height="{{ renderSize }}">
+    {% endif %}
     <svg class="eco-map__overlay"
          viewBox="0 0 {{ renderSize }} {{ renderSize }}"
          width="{{ renderSize }}" height="{{ renderSize }}"
@@ -49,6 +55,11 @@
       {% endfor %}
       {% if owners|length > 16 %}
         <span class="eco-map__legend-more">+{{ owners|length - 16 }} more</span>
+      {% endif %}
+      {% if pollutionDataUri %}
+        <span class="eco-map__legend-pollution" title="Translucent red overlay shows ground pollution density.">
+          ground pollution
+        </span>
       {% endif %}
     </div>
   {% else %}

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,487 @@
+"""Unit tests for the `get_eco_climate` tool.
+
+Covers:
+- ``fetch_climate`` dataset fan-out, candidate-name fallthrough, and
+  graceful degradation when the admin token is absent.
+- ``compute_climate_payload`` math: % change, status classification, real-
+  world Earth CO2 anchor.
+- Polluter attribution via the action-exporter CSV stream.
+- The MCP tool wiring end-to-end (call_tool returns markdown + JSON +
+  the iframe fragment via ``_meta.ui.fragment``).
+- The ``get_eco_map`` pollution overlay pulls ``Layers/Pollution.gif`` and
+  exposes it as ``pollutionDataUri``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import mcp.types as mt
+import pytest
+import respx
+
+from eco_mcp_app import climate as climate_mod
+from eco_mcp_app import map as eco_map
+from eco_mcp_app import server as eco_server
+from eco_mcp_app.climate import (
+    CO2_DATASET_CANDIDATES,
+    EARTH_CO2_HISTORY,
+    POLLUTION_ACTION_TYPES,
+    POLLUTION_DATASET_CANDIDATES,
+    SEA_LEVEL_DATASET_CANDIDATES,
+    ClimateSnapshot,
+    _earth_year_for_ppm,
+    _parse_layer_pct,
+    _percent_change,
+    compute_climate_payload,
+    fetch_climate,
+)
+from eco_mcp_app.server import (
+    DEFAULT_ECO_INFO_URL,
+    UI_META,
+    build_server,
+)
+
+_DEFAULT_BASE = DEFAULT_ECO_INFO_URL.rsplit("/info", 1)[0]
+_DATASET_URL = f"{_DEFAULT_BASE}/datasets/get"
+_WORLDLAYERS_URL = f"{_DEFAULT_BASE}/api/v1/worldlayers/layers"
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each test starts with a clean cache + a known admin token."""
+    eco_server._info_cache.clear()
+    eco_server._economy_cache.clear()
+    eco_server._admin_token_cache.clear()
+    climate_mod._clear_cache()
+    monkeypatch.setenv("ECO_ADMIN_TOKEN", "test-token")
+
+
+def _info(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "Description": "Eco via Sirens",
+        "Category": "Test",
+        "DaysRunning": 4,
+        "TimeSinceStart": 4 * 3600,
+        "EconomyDesc": "100 trades, 0 contracts",
+        "TotalCulture": 50.0,
+    }
+    base.update(overrides)
+    return base
+
+
+def _series(values: list[float]) -> list[dict[str, float]]:
+    return [{"Time": float(i * 3600), "Value": float(v)} for i, v in enumerate(values)]
+
+
+def _route_datasets(values: dict[str, list[float]]) -> None:
+    """Mock /datasets/get with a per-dataset value table.
+
+    Datasets not in `values` return an empty list (mirrors the live
+    behavior for unknown / disabled stat names).
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        name = request.url.params.get("dataset", "")
+        if name in values:
+            return httpx.Response(200, json=_series(values[name]))
+        return httpx.Response(200, json=[])
+
+    respx.get(_DATASET_URL).mock(side_effect=handler)
+
+
+def _route_worldlayers_empty() -> None:
+    respx.get(_WORLDLAYERS_URL).mock(return_value=httpx.Response(200, json=[]))
+
+
+def _route_actions_empty() -> None:
+    """Stub every pollution action endpoint with an empty CSV (just header)."""
+    for action in POLLUTION_ACTION_TYPES:
+        url = f"{_DEFAULT_BASE}/api/v1/exporter/actions?actionName={action}"
+        respx.get(url).mock(return_value=httpx.Response(200, text="Time,Citizen,Count\n"))
+
+
+# ---------------------------------------------------------------------------
+# fetch_climate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_picks_first_nonempty_candidate() -> None:
+    """Of the 4 CO2 candidates, only ``AverageCO2PPM`` returns data."""
+    _route_datasets({"AverageCO2PPM": [400, 410, 420]})
+    _route_worldlayers_empty()
+    _route_actions_empty()
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    assert snap.co2_dataset_name == "AverageCO2PPM"
+    assert [v for _, v in snap.co2_series] == [400.0, 410.0, 420.0]
+    # Sea level + ground pollution are not in the values map → series stay empty.
+    assert snap.sea_level_series == []
+    assert snap.pollution_series == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_skips_admin_path_without_token() -> None:
+    """No token → admin endpoints are never hit, only worldlayers is fetched."""
+    ds_route = respx.get(_DATASET_URL).mock(return_value=httpx.Response(200, json=[]))
+    wl_route = respx.get(_WORLDLAYERS_URL).mock(return_value=httpx.Response(200, json=[]))
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token=None,
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    assert snap.admin_ok is False
+    assert ds_route.call_count == 0
+    assert wl_route.called
+    assert snap.co2_series == [] and snap.sea_level_series == []
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_aggregates_polluter_attribution() -> None:
+    _route_datasets({"CO2PPM": [400, 405]})
+    _route_worldlayers_empty()
+    # `PollutionAction` returns two rows; the rest 404.
+    csv_body = (
+        "Time,Citizen,Count,WorldObjectItem\n"
+        "0,alice,5,GeneratorItem\n"
+        "1,bob,3,GeneratorItem\n"
+        "2,alice,2,SmelterItem\n"
+    )
+    base_actions = f"{_DEFAULT_BASE}/api/v1/exporter/actions"
+    respx.get(f"{base_actions}?actionName=PollutionAction").mock(
+        return_value=httpx.Response(200, text=csv_body)
+    )
+    for action in POLLUTION_ACTION_TYPES:
+        if action == "PollutionAction":
+            continue
+        respx.get(f"{base_actions}?actionName={action}").mock(
+            return_value=httpx.Response(404)
+        )
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    # alice: 5 + 2 = 7, bob: 3.
+    assert snap.top_polluter_citizens[0] == ("alice", 7.0)
+    assert snap.top_polluter_citizens[1] == ("bob", 3.0)
+    # Stations: GeneratorItem 5+3=8, SmelterItem 2.
+    assert snap.top_polluter_stations[0] == ("GeneratorItem", 8.0)
+    assert snap.pollution_actions_total == 3
+    assert "PollutionAction" in snap.pollution_action_types_seen
+    # 404 is benign — the warnings list only carries non-404 problems.
+    assert all("404" not in w for w in snap.warnings)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_caches_within_ttl() -> None:
+    """Repeat calls within the TTL hit the cache, not the network."""
+    _route_datasets({"CO2PPM": [400]})
+    wl = respx.get(_WORLDLAYERS_URL).mock(return_value=httpx.Response(200, json=[]))
+    _route_actions_empty()
+
+    await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+    await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+    # Worldlayers hit only once — second call short-circuited by the TTLCache.
+    assert wl.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# compute_climate_payload
+# ---------------------------------------------------------------------------
+
+
+def _snap(**overrides: object) -> ClimateSnapshot:
+    base = ClimateSnapshot(
+        fetched_at_iso="2026-05-10T00:00:00+00:00",
+        source_base_url=_DEFAULT_BASE,
+        info={"Description": "Eco", "_sourceUrl": DEFAULT_ECO_INFO_URL},
+        days_elapsed=4,
+        admin_ok=True,
+    )
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+def test_payload_status_critical_at_500_ppm() -> None:
+    snap = _snap(co2_series=[(0.0, 480.0), (1.0, 510.0)])
+    p = compute_climate_payload(snap)
+    assert p["status"] == "critical"
+    # Real-world anchor still returns the most recent year, flagged as
+    # "beyond present-day Earth".
+    assert p["earth_match"]["year"] == EARTH_CO2_HISTORY[-1][0]
+
+
+def test_payload_status_warming_above_350_ppm() -> None:
+    snap = _snap(co2_series=[(0.0, 360.0), (1.0, 390.0)])
+    p = compute_climate_payload(snap)
+    assert p["status"] == "warming"
+
+
+def test_payload_status_stable_below_threshold() -> None:
+    snap = _snap(co2_series=[(0.0, 280.0), (1.0, 290.0)])
+    p = compute_climate_payload(snap)
+    assert p["status"] == "stable"
+
+
+def test_payload_status_unknown_without_co2_series() -> None:
+    p = compute_climate_payload(_snap())
+    assert p["status"] == "unknown"
+    assert p["co2"]["current"] is None
+
+
+def test_payload_co2_change_pct_computed_from_first_to_last() -> None:
+    snap = _snap(co2_series=[(0.0, 400.0), (1.0, 412.0)])
+    p = compute_climate_payload(snap)
+    # (412 - 400) / 400 = 3.0 %
+    assert p["co2"]["change_pct"] == 3.0
+
+
+def test_payload_sea_level_rate_per_day() -> None:
+    snap = _snap(
+        sea_level_series=[(0.0, 100.0), (1.0, 100.4)],
+        days_elapsed=4,
+    )
+    p = compute_climate_payload(snap)
+    # rate = (100.4 - 100) / 4 days = 0.1
+    assert p["sea_level"]["rate_per_day"] == 0.1
+
+
+def test_payload_pollution_falls_back_to_worldlayers_when_series_empty() -> None:
+    snap = _snap(pollution_layer_summary="7%")
+    p = compute_climate_payload(snap)
+    assert p["pollution"]["current"] == 7.0
+    assert p["pollution"]["source"] == "worldlayers"
+
+
+def test_payload_pollution_prefers_live_series_over_layer() -> None:
+    snap = _snap(
+        pollution_series=[(0.0, 12.0), (1.0, 14.0)],
+        pollution_layer_summary="7%",
+        pollution_dataset_name="GroundPollution",
+    )
+    p = compute_climate_payload(snap)
+    assert p["pollution"]["current"] == 14.0
+    assert p["pollution"]["source"] == "GroundPollution"
+
+
+def test_payload_attribution_block_when_no_data() -> None:
+    p = compute_climate_payload(_snap())
+    assert p["attribution"]["has_data"] is False
+    assert p["attribution"]["top_citizens"] == []
+
+
+def test_payload_attribution_top_5_only() -> None:
+    snap = _snap(
+        top_polluter_citizens=[(f"player{i}", 10.0 - i) for i in range(8)],
+    )
+    p = compute_climate_payload(snap)
+    assert len(p["attribution"]["top_citizens"]) == 5
+    assert p["attribution"]["top_citizens"][0]["name"] == "player0"
+
+
+def test_payload_admin_unavailable_narrative() -> None:
+    p = compute_climate_payload(_snap(admin_ok=False))
+    assert "Admin token unavailable" in p["narrative"]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_percent_change_handles_zero_baseline() -> None:
+    assert _percent_change(0.0, 100.0) is None
+    assert _percent_change(100.0, 110.0) == 10.0
+
+
+def test_earth_year_for_ppm_returns_closest() -> None:
+    # 339 ppm matches 1980 exactly.
+    match = _earth_year_for_ppm(339.0)
+    assert match is not None and match["year"] == 1980
+
+
+def test_earth_year_for_ppm_flags_beyond_present() -> None:
+    match = _earth_year_for_ppm(500.0)
+    assert match is not None
+    assert "beyond present-day Earth" in match["note"]
+
+
+def test_earth_year_for_ppm_returns_none_far_below_baseline() -> None:
+    assert _earth_year_for_ppm(50.0) is None
+
+
+def test_parse_layer_pct() -> None:
+    assert _parse_layer_pct("4%") == 4.0
+    assert _parse_layer_pct("  12.5 %  ") == 12.5
+    assert _parse_layer_pct(None) is None
+    assert _parse_layer_pct("not a number") is None
+
+
+def test_dataset_candidate_constants_are_nonempty() -> None:
+    """Defensive: ensure we still ship some candidate names if a refactor
+    accidentally empties the tuples."""
+    assert CO2_DATASET_CANDIDATES
+    assert SEA_LEVEL_DATASET_CANDIDATES
+    assert POLLUTION_DATASET_CANDIDATES
+
+
+# ---------------------------------------------------------------------------
+# MCP tool wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tools_includes_get_eco_climate() -> None:
+    mcp = build_server()
+    handler = mcp.request_handlers[mt.ListToolsRequest]
+    result = await handler(mt.ListToolsRequest(method="tools/list"))
+    names = {tool.name for tool in result.root.tools}
+    assert "get_eco_climate" in names
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_call_get_eco_climate_returns_iframe_fragment() -> None:
+    respx.get(DEFAULT_ECO_INFO_URL).mock(return_value=httpx.Response(200, json=_info()))
+    _route_datasets(
+        {
+            "CO2PPM": [400, 405, 410, 415],
+            "SeaLevel": [100.0, 100.05, 100.1, 100.15],
+            "GroundPollution": [3, 4, 5, 6],
+        }
+    )
+    _route_worldlayers_empty()
+    _route_actions_empty()
+
+    mcp = build_server()
+    handler = mcp.request_handlers[mt.CallToolRequest]
+    req = mt.CallToolRequest(
+        method="tools/call",
+        params=mt.CallToolRequestParams(name="get_eco_climate", arguments={}),
+    )
+    result = await handler(req)
+    blocks = result.root.content
+    assert len(blocks) == 2
+    assert isinstance(blocks[0], mt.TextContent)
+    assert isinstance(blocks[1], mt.TextContent)
+
+    # Markdown mentions the headline.
+    md = blocks[0].text
+    assert "climate" in md.lower()
+    assert "ppm" in md.lower()
+
+    # JSON is parseable; carries the snapshot dataset names.
+    snapshot = json.loads(blocks[1].text)
+    assert snapshot["co2DatasetName"] == "CO2PPM"
+    assert snapshot["seaLevelDatasetName"] == "SeaLevel"
+    assert snapshot["pollutionDatasetName"] == "GroundPollution"
+
+    # MCP Apps fragment is on _meta and contains card markup.
+    meta = result.root.meta
+    assert meta is not None
+    assert meta["ui"]["resourceUri"] == UI_META["ui"]["resourceUri"]
+    assert "Climate" in meta["ui"]["fragment"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_call_get_eco_climate_handles_info_failure() -> None:
+    respx.get(DEFAULT_ECO_INFO_URL).mock(side_effect=httpx.ConnectError("refused"))
+    mcp = build_server()
+    handler = mcp.request_handlers[mt.CallToolRequest]
+    req = mt.CallToolRequest(
+        method="tools/call",
+        params=mt.CallToolRequestParams(name="get_eco_climate", arguments={}),
+    )
+    result = await handler(req)
+    assert result.root.isError is True
+    meta = result.root.meta
+    assert meta is not None
+    assert isinstance(meta["ui"]["fragment"], str)
+
+
+# ---------------------------------------------------------------------------
+# Map pollution-overlay extension
+# ---------------------------------------------------------------------------
+
+
+_TINY_GIF = bytes.fromhex(
+    "47494638396101000100800000000000ffffff21f90401000000002c000000000100010000020144003b"
+)
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_map_bundle_includes_pollution_overlay_when_present() -> None:
+    base = "http://eco.coilysiren.me:3001"
+    respx.get(f"{base}/api/v1/map/dimension").mock(
+        return_value=httpx.Response(200, json={"x": 720, "y": 200, "z": 720})
+    )
+    respx.get(f"{base}/api/v1/map/property").mock(return_value=httpx.Response(200, json={}))
+    respx.get(f"{base}/Layers/WorldPreview.gif").mock(
+        return_value=httpx.Response(200, content=_TINY_GIF)
+    )
+    respx.get(f"{base}/Layers/Pollution.gif").mock(
+        return_value=httpx.Response(200, content=_TINY_GIF)
+    )
+
+    bundle = await eco_map.fetch_map_bundle()
+    assert bundle["pollution_gif"] == _TINY_GIF
+    payload = eco_map.build_map_payload(bundle)
+    assert payload["pollutionDataUri"] is not None
+    assert payload["pollutionDataUri"].startswith("data:image/gif;base64,")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_map_bundle_omits_pollution_overlay_when_404() -> None:
+    """Pollution.gif 404 is normal — the map renders fine without it."""
+    base = "http://eco.coilysiren.me:3001"
+    respx.get(f"{base}/api/v1/map/dimension").mock(
+        return_value=httpx.Response(200, json={"x": 720, "y": 200, "z": 720})
+    )
+    respx.get(f"{base}/api/v1/map/property").mock(return_value=httpx.Response(200, json={}))
+    respx.get(f"{base}/Layers/WorldPreview.gif").mock(
+        return_value=httpx.Response(200, content=_TINY_GIF)
+    )
+    respx.get(f"{base}/Layers/Pollution.gif").mock(return_value=httpx.Response(404))
+
+    bundle = await eco_map.fetch_map_bundle()
+    assert bundle["pollution_gif"] is None
+    payload = eco_map.build_map_payload(bundle)
+    assert payload["pollutionDataUri"] is None

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -28,6 +28,7 @@ async def test_list_tools_advertises_all_tools() -> None:
         "fair_price",
         "get_eco_government",
         "get_eco_ecoregion",
+        "get_eco_climate",
     }
 
 


### PR DESCRIPTION
## Summary

Players without polluting machines have no in-game visibility into the global atmospheric trend until sea-level rise reaches their property. This adds an MCP tool that surfaces that data through Claude so any player can see the trajectory before they're affected.

The 4 deliverables you asked for:

- **Baseline** — live CO2 ppm + sea-level height + ground-pollution %, each with a sparkline. Same `/datasets/get` plumbing as `get_eco_economy`.
- **Polluter attribution** — top emitting citizens + stations from the action exporter, same stream-parser as `get_eco_crafting_atlas`. Probes 4 candidate action names (`PollutionAction` / `EmitPollutionAction` / `EmitCO2Action` / `BurnFuelAction`) and aggregates whichever exists.
- **Map overlay** — `get_eco_map` now overlays a translucent red ground-pollution heatmap when `/Layers/Pollution.gif` is served. 404 → omitted gracefully.
- **Real-world anchor** — bundled NOAA Mauna Loa annual averages (1750–2024). Card says e.g. *"Earth crossed this in ~2019"* or *"beyond present-day Earth"* when the in-game ppm exceeds 422.

Defensive design where it matters: dataset names are probed (CO2PPM / AverageCO2PPM / AtmosphereCO2 / CO2 — first non-empty wins) since Eco's stat catalog drifts across versions and mods register their own. Empty data is a valid state, not an error: the card renders with "—" + "no series yet" copy. Without an admin token the card falls back to public worldlayers `Summary` text for a headline pollution percentage.

Status classification: `stable` (<350 ppm) / `warming` (≥350 or sea-level drift ≥1%) / `critical` (≥500 ppm or sea drift ≥5%) — picked to align with Eco's default Sea Level Rise mod thresholds.

## Files

- `src/eco_mcp_app/climate.py` — new module: fetch + payload + Earth anchor + attribution stream-parse
- `src/eco_mcp_app/server.py` — `get_eco_climate` tool def, call_tool branch, render + markdown helpers, `_attach_climate_sparklines`
- `src/eco_mcp_app/templates/partials/climate_card.html` — Jinja partial
- `src/eco_mcp_app/templates/eco.css` — `.climate-badge`, `.narrative-{stable,warming,critical}`, `.earth-anchor`, `.climate-rank`, `.eco-map__pollution` overlay
- `src/eco_mcp_app/map.py` + `templates/partials/map.html` — pollution overlay wiring
- `tests/test_climate.py` — fetch fan-out, candidate fallthrough, classification thresholds, real-world anchor, MCP tool wiring, map overlay present/absent
- `tests/test_tools.py` — add `get_eco_climate` to the advertised set
- `docs/FEATURES.md` — describe the new tool, bump 11→12

## Test plan

- [ ] `make test` — exercises new `tests/test_climate.py` and the existing `tests/test_map.py` (the latter relies on `httpx.HTTPError` catching the unmocked Pollution.gif call and falling back to `pollution_gif=None` — verify no regression)
- [ ] `make ruff` — formatting / lint clean
- [ ] `make smoke` — the stdio handshake exercises `tools/list`; should now show 12 tools
- [ ] Browser preview the card via `make harness` against the live server (CO2 series will populate or render the empty-state — both are valid)
- [ ] After deploy, verify dataset-name probe finds at least one of the candidates on the live server; if none, the card surfaces "no atmospheric series exposed by this server yet" rather than failing
- [ ] If the live server doesn't serve `/Layers/Pollution.gif`, confirm `get_eco_map` still renders normally without the overlay

Sandbox couldn't run `make ruff` / `make test` (lockdown blocks `uv` / `make` / `python` / `coily`), so CI is the validation gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mshfh2FqLvF8D3BSTMitYw)_