### PR TITLE
climate: discover dataset names via /datasets/flatlist

### DIFF
--- a/src/eco_mcp_app/climate.py
+++ b/src/eco_mcp_app/climate.py
@@ -127,6 +127,10 @@ class ClimateSnapshot:
     top_polluter_stations: list[tuple[str, float]] = field(default_factory=list)
     pollution_actions_total: int = 0
     pollution_action_types_seen: list[str] = field(default_factory=list)
+    # Climate-related dataset names exposed by /datasets/flatlist on this
+    # server. Surfaced on the card so an empty-data path is debuggable
+    # without the user having to grep server logs.
+    available_climate_datasets: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -146,6 +150,7 @@ class ClimateSnapshot:
             "topPolluterStations": [[n, c] for n, c in self.top_polluter_stations],
             "pollutionActionsTotal": self.pollution_actions_total,
             "pollutionActionTypesSeen": list(self.pollution_action_types_seen),
+            "availableClimateDatasets": list(self.available_climate_datasets),
             "warnings": list(self.warnings),
         }
 
@@ -216,18 +221,80 @@ async def _fetch_first_nonempty(
     candidates: tuple[str, ...],
     day_end: int,
     headers: dict[str, str],
+    *,
+    flatlist: list[str] | None = None,
+    discovery_keywords: tuple[str, ...] = (),
 ) -> tuple[str | None, list[tuple[float, float]]]:
     """Try each candidate dataset name; return the first that has data.
 
     Probes are issued sequentially because we want to *stop* on the first hit
     rather than fan out. The catalog is small (3-4 names) and most servers
     will hit on the first probe, so the sequential cost is minimal.
+
+    Fallback: if no explicit candidate matches and ``flatlist`` is given,
+    scan it for any name containing one of the ``discovery_keywords`` and
+    try that. Stat names drift across Eco versions (and mods can register
+    their own), so the catalog-driven fallback is what keeps the card
+    populated when our hard-coded candidates miss.
     """
     for name in candidates:
         pts = await _fetch_dataset(client, base, name, day_end, headers)
         if pts:
             return name, pts
+    if flatlist and discovery_keywords:
+        seen = {c.lower() for c in candidates}
+        for name in flatlist:
+            lower = str(name).lower()
+            if lower in seen:
+                continue
+            if any(kw in lower for kw in discovery_keywords):
+                pts = await _fetch_dataset(client, base, name, day_end, headers)
+                if pts:
+                    return name, pts
     return None, []
+
+
+async def _fetch_dataset_flatlist(
+    client: httpx.AsyncClient, base: str, headers: dict[str, str]
+) -> list[str]:
+    """GET ``/datasets/flatlist`` — the catalog of all dataset stat names.
+
+    Eco's stat catalog can shift across versions (and mods register their
+    own names), so the explicit candidate lists in this module can miss.
+    The flatlist is the source of truth — we use it to discover climate
+    datasets when our hard-coded candidates don't match.
+
+    Returns ``[]`` on any non-200, missing endpoint, or unexpected shape.
+    """
+    try:
+        r = await client.get(f"{base}/datasets/flatlist", headers=headers)
+        if r.status_code != 200:
+            return []
+        data = r.json()
+    except (httpx.HTTPError, ValueError):
+        return []
+    if isinstance(data, list):
+        return [str(x) for x in data if x]
+    # Some Eco builds wrap the list under a key. Be defensive.
+    if isinstance(data, dict):
+        for key in ("datasets", "Datasets", "values", "Values"):
+            v = data.get(key)
+            if isinstance(v, list):
+                return [str(x) for x in v if x]
+    return []
+
+
+# Substring keywords for the flatlist-based fallback. Lowercase, matched
+# against the lowercased dataset name. Kept narrow so we don't accidentally
+# pick up unrelated stats (e.g. "co2" alone instead of "carbon" because
+# "carbonate" would also match the latter).
+CO2_DISCOVERY_KEYWORDS: tuple[str, ...] = ("co2", "ppm", "carbondioxide")
+SEA_LEVEL_DISCOVERY_KEYWORDS: tuple[str, ...] = ("sealevel", "sea level", "ocean level")
+POLLUTION_DISCOVERY_KEYWORDS: tuple[str, ...] = (
+    "groundpollution",
+    "airpollution",
+    "pollution",
+)
 
 
 async def _fetch_pollution_layer_summary(
@@ -384,9 +451,21 @@ async def fetch_climate(
         layer_task = asyncio.create_task(_fetch_pollution_layer_summary(client, base))
 
         if admin_token:
+            # Pull the dataset catalog up front so the per-series probes can
+            # fall back to keyword discovery when our hard-coded candidates
+            # miss (Eco renames stats across versions; mods register their
+            # own).
+            flatlist = await _fetch_dataset_flatlist(client, base, headers)
+
             co2_task = asyncio.create_task(
                 _fetch_first_nonempty(
-                    client, base, CO2_DATASET_CANDIDATES, snapshot.days_elapsed, headers
+                    client,
+                    base,
+                    CO2_DATASET_CANDIDATES,
+                    snapshot.days_elapsed,
+                    headers,
+                    flatlist=flatlist,
+                    discovery_keywords=CO2_DISCOVERY_KEYWORDS,
                 )
             )
             sea_task = asyncio.create_task(
@@ -396,6 +475,8 @@ async def fetch_climate(
                     SEA_LEVEL_DATASET_CANDIDATES,
                     snapshot.days_elapsed,
                     headers,
+                    flatlist=flatlist,
+                    discovery_keywords=SEA_LEVEL_DISCOVERY_KEYWORDS,
                 )
             )
             poll_task = asyncio.create_task(
@@ -405,12 +486,30 @@ async def fetch_climate(
                     POLLUTION_DATASET_CANDIDATES,
                     snapshot.days_elapsed,
                     headers,
+                    flatlist=flatlist,
+                    discovery_keywords=POLLUTION_DISCOVERY_KEYWORDS,
                 )
             )
 
             (snapshot.co2_dataset_name, snapshot.co2_series) = await co2_task
             (snapshot.sea_level_dataset_name, snapshot.sea_level_series) = await sea_task
             (snapshot.pollution_dataset_name, snapshot.pollution_series) = await poll_task
+
+            # Surface every climate-related dataset name the catalog
+            # exposes so the empty-state card can hint at why we found
+            # nothing, and so future debugging doesn't need server logs.
+            climate_kws = (
+                CO2_DISCOVERY_KEYWORDS
+                + SEA_LEVEL_DISCOVERY_KEYWORDS
+                + POLLUTION_DISCOVERY_KEYWORDS
+            )
+            snapshot.available_climate_datasets = sorted(
+                {
+                    name
+                    for name in flatlist
+                    if any(kw in name.lower() for kw in climate_kws)
+                }
+            )
 
             # Polluter attribution. Sequential per-action because the exporter
             # CSVs can be many MB late-cycle; we stream-parse each one in turn
@@ -578,6 +677,7 @@ def compute_climate_payload(snapshot: ClimateSnapshot) -> dict[str, Any]:
         sea_change_pct=sea_change_pct,
         admin_ok=snapshot.admin_ok,
         any_series=bool(snapshot.co2_series or snapshot.sea_level_series),
+        available_climate_datasets=snapshot.available_climate_datasets,
     )
 
     return {
@@ -626,6 +726,7 @@ def compute_climate_payload(snapshot: ClimateSnapshot) -> dict[str, Any]:
             ],
         },
         "warnings": list(snapshot.warnings),
+        "available_climate_datasets": list(snapshot.available_climate_datasets),
         "fetched_at_iso": snapshot.fetched_at_iso,
         "source_base_url": snapshot.source_base_url,
     }
@@ -639,6 +740,7 @@ def _narrative(
     sea_change_pct: float | None,
     admin_ok: bool,
     any_series: bool,
+    available_climate_datasets: list[str] | None = None,
 ) -> str:
     """One-sentence summary for the card header."""
     if not admin_ok and not any_series:
@@ -647,7 +749,21 @@ def _narrative(
             "CO2 and sea-level series require ECO_ADMIN_TOKEN."
         )
     if not any_series:
-        return "No atmospheric series exposed by this server yet."
+        # When the catalog *did* expose climate datasets but none had values,
+        # call that out specifically — it's a different failure mode from
+        # "this server's stat catalog has no climate stats at all" and the
+        # latter usually means a mod is missing.
+        if available_climate_datasets:
+            sample = ", ".join(f"`{n}`" for n in available_climate_datasets[:5])
+            return (
+                f"Server exposes climate datasets ({sample}) but none have "
+                "recorded values yet — early in the cycle, or the polluting "
+                "machinery hasn't run."
+            )
+        return (
+            "No atmospheric series exposed by this server's stat catalog. "
+            "Likely a missing climate / pollution mod, or a vanilla ruleset."
+        )
 
     bits: list[str] = []
     if co2_ppm:
@@ -704,10 +820,13 @@ def _clear_cache() -> None:
 
 __all__ = [
     "CO2_DATASET_CANDIDATES",
+    "CO2_DISCOVERY_KEYWORDS",
     "EARTH_CO2_HISTORY",
     "POLLUTION_ACTION_TYPES",
     "POLLUTION_DATASET_CANDIDATES",
+    "POLLUTION_DISCOVERY_KEYWORDS",
     "SEA_LEVEL_DATASET_CANDIDATES",
+    "SEA_LEVEL_DISCOVERY_KEYWORDS",
     "ClimateSnapshot",
     "compute_climate_payload",
     "fetch_climate",

--- a/src/eco_mcp_app/server.py
+++ b/src/eco_mcp_app/server.py
@@ -1652,6 +1652,7 @@ def _render_climate_card(payload: dict[str, Any]) -> str:
         earth_match=payload.get("earth_match"),
         attribution=payload["attribution"],
         warnings=payload.get("warnings") or [],
+        available_climate_datasets=payload.get("available_climate_datasets") or [],
         fetched_at=fetched_at,
         steam_url=STEAM_URL,
         banner_src=_BANNER_SRC,

--- a/src/eco_mcp_app/templates/partials/climate_card.html
+++ b/src/eco_mcp_app/templates/partials/climate_card.html
@@ -41,6 +41,14 @@
     and polluter attribution.
   </div>
   {%- endif %}
+  {%- if available_climate_datasets %}
+  <div class="hint" style="margin-top:6px">
+    Catalog exposes:
+    {%- for name in available_climate_datasets %}
+      <code>{{ name }}</code>{{ "," if not loop.last else "" }}
+    {%- endfor %}
+  </div>
+  {%- endif %}
 </div>
 
 <div class="grid">

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -102,6 +102,12 @@ def _route_actions_empty() -> None:
         respx.get(url).mock(return_value=httpx.Response(200, text="Time,Citizen,Count\n"))
 
 
+def _route_flatlist(names: list[str]) -> None:
+    respx.get(f"{_DEFAULT_BASE}/datasets/flatlist").mock(
+        return_value=httpx.Response(200, json=names)
+    )
+
+
 # ---------------------------------------------------------------------------
 # fetch_climate
 # ---------------------------------------------------------------------------
@@ -112,6 +118,7 @@ def _route_actions_empty() -> None:
 async def test_fetch_climate_picks_first_nonempty_candidate() -> None:
     """Of the 4 CO2 candidates, only ``AverageCO2PPM`` returns data."""
     _route_datasets({"AverageCO2PPM": [400, 410, 420]})
+    _route_flatlist([])
     _route_worldlayers_empty()
     _route_actions_empty()
 
@@ -135,6 +142,9 @@ async def test_fetch_climate_picks_first_nonempty_candidate() -> None:
 async def test_fetch_climate_skips_admin_path_without_token() -> None:
     """No token → admin endpoints are never hit, only worldlayers is fetched."""
     ds_route = respx.get(_DATASET_URL).mock(return_value=httpx.Response(200, json=[]))
+    fl_route = respx.get(f"{_DEFAULT_BASE}/datasets/flatlist").mock(
+        return_value=httpx.Response(200, json=[])
+    )
     wl_route = respx.get(_WORLDLAYERS_URL).mock(return_value=httpx.Response(200, json=[]))
 
     snap = await fetch_climate(
@@ -147,6 +157,9 @@ async def test_fetch_climate_skips_admin_path_without_token() -> None:
 
     assert snap.admin_ok is False
     assert ds_route.call_count == 0
+    # Flatlist also requires admin perms in many setups; skipping it when no
+    # token is consistent with the rest of the admin-gated path.
+    assert fl_route.call_count == 0
     assert wl_route.called
     assert snap.co2_series == [] and snap.sea_level_series == []
 
@@ -155,6 +168,7 @@ async def test_fetch_climate_skips_admin_path_without_token() -> None:
 @respx.mock
 async def test_fetch_climate_aggregates_polluter_attribution() -> None:
     _route_datasets({"CO2PPM": [400, 405]})
+    _route_flatlist([])
     _route_worldlayers_empty()
     # `PollutionAction` returns two rows; the rest 404.
     csv_body = (
@@ -198,6 +212,7 @@ async def test_fetch_climate_aggregates_polluter_attribution() -> None:
 async def test_fetch_climate_caches_within_ttl() -> None:
     """Repeat calls within the TTL hit the cache, not the network."""
     _route_datasets({"CO2PPM": [400]})
+    _route_flatlist([])
     wl = respx.get(_WORLDLAYERS_URL).mock(return_value=httpx.Response(200, json=[]))
     _route_actions_empty()
 
@@ -217,6 +232,72 @@ async def test_fetch_climate_caches_within_ttl() -> None:
     )
     # Worldlayers hit only once — second call short-circuited by the TTLCache.
     assert wl.call_count == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_falls_back_to_flatlist_discovery() -> None:
+    """When no candidate matches but flatlist exposes a CO2-keyword name,
+    the second-pass discovery probe finds it and returns its data."""
+    # None of CO2_DATASET_CANDIDATES match the live name on this server.
+    _route_datasets({"WorldCO2Level": [380, 410]})
+    _route_flatlist(
+        [
+            "WorldCO2Level",  # CO2 match
+            "TidalSeaLevelHeight",  # sea-level match
+            "AirPollutionPerRegion",  # pollution match
+            "OfferedLoanOrBond",  # noise — should be ignored
+        ]
+    )
+    _route_worldlayers_empty()
+    _route_actions_empty()
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    # CO2 series populated via the discovery fallback, not the candidate list.
+    assert snap.co2_dataset_name == "WorldCO2Level"
+    assert [v for _, v in snap.co2_series] == [380.0, 410.0]
+    # Catalog filtered to the climate-relevant subset (the noise name is gone).
+    assert "OfferedLoanOrBond" not in snap.available_climate_datasets
+    assert "WorldCO2Level" in snap.available_climate_datasets
+    assert "TidalSeaLevelHeight" in snap.available_climate_datasets
+    assert "AirPollutionPerRegion" in snap.available_climate_datasets
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_surfaces_catalog_when_all_series_empty() -> None:
+    """Real-world failure mode: flatlist exposes climate names but every
+    series returns empty (early cycle, or no industry yet). Card should
+    name the available datasets so the empty state is debuggable."""
+    # All explicit candidates AND the discovery-matched name return empty.
+    respx.get(_DATASET_URL).mock(return_value=httpx.Response(200, json=[]))
+    _route_flatlist(["CO2 PPM", "Pollution"])
+    _route_worldlayers_empty()
+    _route_actions_empty()
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    assert snap.co2_series == []
+    assert snap.available_climate_datasets == ["CO2 PPM", "Pollution"]
+
+    payload = compute_climate_payload(snap)
+    # Narrative explicitly references the catalog so users know the issue
+    # is "no values yet", not "no climate stats at all".
+    assert "CO2 PPM" in payload["narrative"]
+    assert "exposes climate datasets" in payload["narrative"]
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +466,7 @@ async def test_call_get_eco_climate_returns_iframe_fragment() -> None:
             "GroundPollution": [3, 4, 5, 6],
         }
     )
+    _route_flatlist([])
     _route_worldlayers_empty()
     _route_actions_empty()
 


### PR DESCRIPTION
## Summary

Live testing on cycle 13 (Eco 0.13.0.3) showed the climate card rendering cleanly but every series empty — none of the hard-coded candidate names (`CO2PPM`, `AverageCO2PPM`, etc.) matched what this server's stat catalog exposes. Eco's stat names drift across versions and mods register their own, so a static candidate list will always lag.

**Fix:** after the explicit candidates miss, fetch `/datasets/flatlist` (the authoritative catalog) and probe any name containing a climate keyword (`co2` / `ppm`, `sealevel`, `pollution`, etc.). The first hit with data wins. Sequential probing inside one async task — the catalog is small.

Also surface the catalog-matched climate dataset names on the card so the empty-state path is debuggable without server logs. When every series returns empty but the catalog *does* expose climate stats, the narrative now reads:

> Server exposes climate datasets (`CO2 PPM`, `Pollution`) but none have recorded values yet — early in the cycle, or the polluting machinery hasn't run.

…instead of the generic "no atmospheric series" copy from before.

## Files

- `src/eco_mcp_app/climate.py` — `_fetch_dataset_flatlist`, discovery keyword tuples, fallback wired into `_fetch_first_nonempty`, `available_climate_datasets` on the snapshot, narrative branch
- `src/eco_mcp_app/server.py` — pass `available_climate_datasets` to the Jinja card
- `src/eco_mcp_app/templates/partials/climate_card.html` — render the catalog hint when present
- `tests/test_climate.py` — two new tests (discovery fallback finds a match; catalog surfaced when all series empty); existing tests stub the new flatlist endpoint

## Test plan

- [ ] `make test` covers the new discovery path + the empty-but-catalog-known narrative branch
- [ ] After deploy, the live card on `eco.coilysiren.me` should either populate (if the server emits CO2 / sea-level data under any matching name) or list the catalog datasets that *do* exist so we can extend the keywords list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mshfh2FqLvF8D3BSTMitYw)_