### PR TITLE
climate: parse Eco 0.13 dict-shape flatlist + ContinuousValue _id key

### DIFF
--- a/src/eco_mcp_app/climate.py
+++ b/src/eco_mcp_app/climate.py
@@ -43,9 +43,16 @@ from cachetools import TTLCache
 
 # Candidate dataset names. We try each in order and use the first that
 # returns at least one point. An empty result simply means the server
-# doesn't expose that name — not an error. Order is "most-likely first"
-# based on Eco's published stat catalog and common modded names.
+# doesn't expose that name — not an error.
+#
+# Live catalog discovery on Eco 0.13.0.3 (cycle 13) confirmed the
+# canonical names listed first; older Eco builds used different forms
+# (`CO2PPM`, `AverageCO2PPM`) so both are kept for backward compat.
 CO2_DATASET_CANDIDATES: tuple[str, ...] = (
+    "TotalCO2",
+    "LifetimeCO2FromPollution",
+    "LifetimeCO2FromAnimals",
+    "LifetimeCO2FromPlants",
     "CO2PPM",
     "AverageCO2PPM",
     "AtmosphereCO2",
@@ -57,14 +64,18 @@ SEA_LEVEL_DATASET_CANDIDATES: tuple[str, ...] = (
     "OceanLevel",
 )
 POLLUTION_DATASET_CANDIDATES: tuple[str, ...] = (
+    "TotalGroundPollution",
     "GroundPollution",
     "AveragePollution",
     "Pollution",
 )
 
-# Action names for polluter attribution. Same defensive multi-name approach
-# — the exporter returns 404 / empty for unknown names, which we silently skip.
+# Action names for polluter attribution. `PolluteAir` is the canonical
+# event-stat on Eco 0.13.0.3 ("Air pollution was released (triggered every
+# 30 sec of operation)"). Older candidate names are kept for backward
+# compatibility with modded / older servers.
 POLLUTION_ACTION_TYPES: tuple[str, ...] = (
+    "PolluteAir",
     "PollutionAction",
     "EmitPollutionAction",
     "EmitCO2Action",
@@ -201,18 +212,67 @@ async def _fetch_dataset(
     out: list[tuple[float, float]] = []
     if isinstance(data, list):
         for pt in data:
-            if isinstance(pt, dict):
-                t = pt.get("Time", pt.get("time"))
-                v = pt.get("Value", pt.get("value"))
-            elif isinstance(pt, list | tuple) and len(pt) >= 2:
-                t, v = pt[0], pt[1]
-            else:
-                continue
-            try:
-                out.append((float(t), float(v)))
-            except (TypeError, ValueError):
-                continue
+            parsed = _parse_dataset_point(pt)
+            if parsed is not None:
+                out.append(parsed)
     return out
+
+
+# Time-key candidates ordered by how common each form is in the wild:
+# - ``Time`` is the event-stat / older economy-stat convention.
+# - ``_id`` is the ContinuousValue convention on Eco 0.13.0.3 (per the
+#   stat catalog's ``TimeKey`` metadata).
+_DATASET_TIME_KEYS: tuple[str, ...] = ("Time", "time", "_id", "Id", "T")
+
+
+def _parse_dataset_point(pt: Any) -> tuple[float, float] | None:
+    """Coerce one ``/datasets/get`` point to ``(time, value)``.
+
+    Tolerates several shapes seen across Eco versions:
+
+    - ``{"Time": t, "Value": v}`` — legacy economy stats, event stats.
+    - ``{"_id": t, "Value": v}`` — ContinuousValue stats on 0.13.0.3.
+    - ``{"_id": t, "<ShortName>": v}`` — same, but the value lives under
+      the stat's short-name key (e.g. ``"tl"`` for ``TotalCO2``). We
+      identify it as "the only numeric field that isn't the time key".
+    - ``[t, v]`` — flat tuple pair, occasionally returned by mod stats.
+
+    Returns ``None`` if neither time nor value can be recovered — the
+    caller drops the point.
+    """
+    if isinstance(pt, list | tuple) and len(pt) >= 2:
+        try:
+            return float(pt[0]), float(pt[1])
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(pt, dict):
+        return None
+    time_key: str | None = None
+    t_raw: Any = None
+    for k in _DATASET_TIME_KEYS:
+        if k in pt:
+            time_key = k
+            t_raw = pt[k]
+            break
+    if time_key is None:
+        return None
+    v_raw: Any = pt.get("Value", pt.get("value"))
+    if v_raw is None:
+        # Fall back to "the lone numeric field that isn't the time key" —
+        # handles ContinuousValue points where the value lives under the
+        # stat's ShortName (e.g. {"_id": 123, "tl": 414.2}).
+        for k, val in pt.items():
+            if k == time_key:
+                continue
+            if isinstance(val, int | float) and not isinstance(val, bool):
+                v_raw = val
+                break
+    if v_raw is None:
+        return None
+    try:
+        return float(t_raw), float(v_raw)
+    except (TypeError, ValueError):
+        return None
 
 
 async def _fetch_first_nonempty(
@@ -264,6 +324,13 @@ async def _fetch_dataset_flatlist(
     The flatlist is the source of truth — we use it to discover climate
     datasets when our hard-coded candidates don't match.
 
+    Response shape varies by Eco version:
+    - 0.13.0.3 returns ``list[dict]`` where each dict has rich metadata
+      (``Name``, ``DisplayName``, ``Unit``, ``Tags``, ``StatType``, ...).
+      We extract ``Name`` — that's what ``/datasets/get?dataset=...`` uses.
+    - Older / modded builds may return ``list[str]`` directly.
+    Both shapes are normalized to a plain list of canonical names.
+
     Returns ``[]`` on any non-200, missing endpoint, or unexpected shape.
     """
     try:
@@ -273,15 +340,27 @@ async def _fetch_dataset_flatlist(
         data = r.json()
     except (httpx.HTTPError, ValueError):
         return []
-    if isinstance(data, list):
-        return [str(x) for x in data if x]
-    # Some Eco builds wrap the list under a key. Be defensive.
+    # Some Eco builds wrap the list under a key.
     if isinstance(data, dict):
         for key in ("datasets", "Datasets", "values", "Values"):
             v = data.get(key)
             if isinstance(v, list):
-                return [str(x) for x in v if x]
-    return []
+                data = v
+                break
+        else:
+            return []
+    if not isinstance(data, list):
+        return []
+    out: list[str] = []
+    for entry in data:
+        if isinstance(entry, str):
+            if entry:
+                out.append(entry)
+        elif isinstance(entry, dict):
+            name = entry.get("Name") or entry.get("name")
+            if name:
+                out.append(str(name))
+    return out
 
 
 # Substring keywords for the flatlist-based fallback. Lowercase, matched

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -32,6 +32,7 @@ from eco_mcp_app.climate import (
     SEA_LEVEL_DATASET_CANDIDATES,
     ClimateSnapshot,
     _earth_year_for_ppm,
+    _parse_dataset_point,
     _parse_layer_pct,
     _percent_change,
     compute_climate_payload,
@@ -103,8 +104,31 @@ def _route_actions_empty() -> None:
 
 
 def _route_flatlist(names: list[str]) -> None:
+    """Stub flatlist with a plain list-of-strings (old Eco shape)."""
     respx.get(f"{_DEFAULT_BASE}/datasets/flatlist").mock(
         return_value=httpx.Response(200, json=names)
+    )
+
+
+def _route_flatlist_dicts(names: list[str]) -> None:
+    """Stub flatlist with the dict-shape Eco 0.13.0.3 actually returns.
+
+    Each entry is a minimal subset of the live-catalog response so the
+    parser exercise is identical to production.
+    """
+    catalog = [
+        {
+            "Name": name,
+            "DisplayName": name,
+            "Unit": "PPM",
+            "StatType": "ContinuousValue",
+            "Tags": ["Climate"],
+            "TimeKey": "_id",
+        }
+        for name in names
+    ]
+    respx.get(f"{_DEFAULT_BASE}/datasets/flatlist").mock(
+        return_value=httpx.Response(200, json=catalog)
     )
 
 
@@ -268,6 +292,47 @@ async def test_fetch_climate_falls_back_to_flatlist_discovery() -> None:
     assert "WorldCO2Level" in snap.available_climate_datasets
     assert "TidalSeaLevelHeight" in snap.available_climate_datasets
     assert "AirPollutionPerRegion" in snap.available_climate_datasets
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_parses_dict_shape_flatlist() -> None:
+    """Eco 0.13.0.3 returns flatlist as a list of dicts with metadata.
+
+    Real-world regression: the catalog leaked through as full ``{'Name': ...}``
+    strings on the empty-state card because we were stringifying each entry
+    instead of extracting ``Name``. Verify the canonical name is what we
+    surface and what we probe.
+    """
+    _route_datasets({"TotalCO2": [400, 415]})
+    _route_flatlist_dicts(
+        [
+            "TotalCO2",
+            "SeaLevel",
+            "TotalGroundPollution",
+            "OfferedLoanOrBond",  # non-climate, must be filtered out
+        ]
+    )
+    _route_worldlayers_empty()
+    _route_actions_empty()
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    # CO2 candidate hit on the first try (TotalCO2 is at the head now).
+    assert snap.co2_dataset_name == "TotalCO2"
+    # Clean names, not dict reprs.
+    assert "TotalCO2" in snap.available_climate_datasets
+    assert "SeaLevel" in snap.available_climate_datasets
+    assert "TotalGroundPollution" in snap.available_climate_datasets
+    assert not any(
+        "{" in n or "'Name'" in n for n in snap.available_climate_datasets
+    )
 
 
 @pytest.mark.asyncio
@@ -439,6 +504,47 @@ def test_dataset_candidate_constants_are_nonempty() -> None:
     assert CO2_DATASET_CANDIDATES
     assert SEA_LEVEL_DATASET_CANDIDATES
     assert POLLUTION_DATASET_CANDIDATES
+
+
+def test_canonical_eco_0_13_names_in_candidates() -> None:
+    """Live-catalog regression: the canonical Eco 0.13.0.3 names must be in
+    the candidate lists so the first probe hits without needing flatlist."""
+    assert "TotalCO2" in CO2_DATASET_CANDIDATES
+    assert "SeaLevel" in SEA_LEVEL_DATASET_CANDIDATES
+    assert "TotalGroundPollution" in POLLUTION_DATASET_CANDIDATES
+    assert "PolluteAir" in POLLUTION_ACTION_TYPES
+
+
+def test_parse_dataset_point_legacy_time_value_shape() -> None:
+    assert _parse_dataset_point({"Time": 100, "Value": 1.5}) == (100.0, 1.5)
+    assert _parse_dataset_point({"time": 100, "value": 1.5}) == (100.0, 1.5)
+
+
+def test_parse_dataset_point_continuousvalue_id_shape() -> None:
+    """Eco 0.13.0.3 ContinuousValue stats key the time on ``_id``."""
+    assert _parse_dataset_point({"_id": 250, "Value": 414.2}) == (250.0, 414.2)
+
+
+def test_parse_dataset_point_shortname_value_shape() -> None:
+    """Some ContinuousValue stats put the value under the stat's ShortName
+    (e.g. ``"tl"`` for ``TotalCO2``). We accept "the lone numeric field that
+    isn't the time key" so the value still flows through."""
+    pt = {"_id": 300, "tl": 416.5}
+    assert _parse_dataset_point(pt) == (300.0, 416.5)
+
+
+def test_parse_dataset_point_flat_pair_shape() -> None:
+    assert _parse_dataset_point([100, 1.5]) == (100.0, 1.5)
+    assert _parse_dataset_point((100, 1.5)) == (100.0, 1.5)
+
+
+def test_parse_dataset_point_drops_invalid() -> None:
+    assert _parse_dataset_point({"Value": 1.5}) is None  # no time key
+    assert _parse_dataset_point({"Time": 100}) is None  # no value
+    assert _parse_dataset_point("garbage") is None
+    assert _parse_dataset_point(None) is None
+    # Boolean fields must not be picked up as the numeric value.
+    assert _parse_dataset_point({"_id": 1, "IsPaused": True}) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Live retest exposed two distinct bugs that compounded into "card renders but no data":

### 1. Flatlist parser treated dict entries as strings

Eco 0.13.0.3 returns `/datasets/flatlist` as `list[dict]` (each entry has `Name`, `DisplayName`, `Unit`, `Tags`, `StatType`, `TimeKey`, `ShortName`). My code from #32 expected `list[str]`, so it stringified each dict, matched keywords against the `repr()`, then fed the stringified dict back into `/datasets/get?dataset=...` — which 404'd every time. The narrative + catalog hint also leaked the raw `{'Name': ...}` repr to the card:

> Catalog exposes: `{'Name': 'TotalCO2', 'DisplayName': 'Total CO2', 'Unit': 'PPM', ...}`, `{'Name': 'SeaLevel', ...}`

**Fix:** `_fetch_dataset_flatlist` now handles both shapes (list-of-strings AND list-of-dicts) and extracts `Name` from each entry.

### 2. ContinuousValue stats use `_id` as the time key, not `Time`

`TotalCO2`, `SeaLevel`, `TotalGroundPollution` etc. are `ContinuousValue` stats with `TimeKey: "_id"` per the catalog metadata. Some return values keyed under the stat's `ShortName` (e.g. `"tl"` for `TotalCO2`). The existing point parser only knew the `{Time, Value}` shape, so every point was silently dropped — even when the explicit `SeaLevel` candidate hit the right endpoint.

**Fix:** new `_parse_dataset_point` tries `Time` / `time` / `_id` / `Id` / `T` for the time key and falls back to "the lone numeric field that isn't the time key" for the value (handles ShortName-keyed responses).

### 3. Canonical name updates from the live catalog

Promoted the actual Eco 0.13.0.3 names to the head of the candidate lists so the first probe hits without needing the flatlist fallback:

- CO2: `TotalCO2`, `LifetimeCO2FromPollution`, `LifetimeCO2FromAnimals`, `LifetimeCO2FromPlants`
- Pollution: `TotalGroundPollution`
- Action: `PolluteAir` (description: *"Air pollution was released (triggered every 30 sec of operation)"*)

## Files

- `src/eco_mcp_app/climate.py` — new `_parse_dataset_point`, dict-shape flatlist parsing, canonical names promoted, `PolluteAir` action
- `tests/test_climate.py` — new test fixture `_route_flatlist_dicts` that mirrors the 0.13.0.3 shape; new tests for each parser shape variant; canary test asserts canonical names stay in the candidate lists

## Test plan

- [ ] Retest live: card should populate with real CO2 / sea-level / ground-pollution numbers from `eco.coilysiren.me` cycle 13
- [ ] Empty-state hint should show clean names (`TotalCO2`, `SeaLevel`, …) not dict reprs
- [ ] If data still doesn't flow, the parser tests at least eliminate "shape mismatch" as the cause — next move would be inspecting raw `/datasets/get?dataset=TotalCO2` response shape directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mshfh2FqLvF8D3BSTMitYw)_