### PR TITLE
climate: parse parallel-array dataset payloads

### DIFF
--- a/src/eco_mcp_app/climate.py
+++ b/src/eco_mcp_app/climate.py
@@ -110,7 +110,7 @@ _CRITICAL_PPM = 500.0
 # TTL is plenty and prevents the iframe-on-refresh case from hammering the
 # admin endpoint.
 _CACHE_TTL_S = float(os.environ.get("ECO_CLIMATE_CACHE_TTL", "60"))
-_climate_cache: TTLCache[str, "ClimateSnapshot"] = TTLCache(maxsize=64, ttl=_CACHE_TTL_S)
+_climate_cache: TTLCache[str, ClimateSnapshot] = TTLCache(maxsize=64, ttl=_CACHE_TTL_S)
 
 # Action exporter row cap — same defensive bound as crafting.py uses.
 _MAX_ROWS_PER_ACTION = int(os.environ.get("ECO_CLIMATE_MAX_ROWS", "200000"))
@@ -215,7 +215,29 @@ async def _fetch_dataset(
             parsed = _parse_dataset_point(pt)
             if parsed is not None:
                 out.append(parsed)
+    elif isinstance(data, dict):
+        out.extend(_parse_parallel_arrays(data))
     return out
+
+
+def _parse_parallel_arrays(data: dict[str, Any]) -> list[tuple[float, float]]:
+    """Zip an Eco 0.13 parallel-array dataset payload to ``[(t, v), ...]``.
+
+    Live ContinuousValue stats on Eco 0.13.0.3 return:
+        {"Times": [...], "Values": [...], "Interval": N, "Unit": "PPM"}
+    instead of a list of point dicts. Both keys are case-tolerant.
+    """
+    times = data.get("Times") or data.get("times")
+    values = data.get("Values") or data.get("values")
+    if not isinstance(times, list) or not isinstance(values, list):
+        return []
+    pairs: list[tuple[float, float]] = []
+    for t_raw, v_raw in zip(times, values, strict=False):
+        try:
+            pairs.append((float(t_raw), float(v_raw)))
+        except (TypeError, ValueError):
+            continue
+    return pairs
 
 
 # Time-key candidates ordered by how common each form is in the wild:
@@ -376,9 +398,7 @@ POLLUTION_DISCOVERY_KEYWORDS: tuple[str, ...] = (
 )
 
 
-async def _fetch_pollution_layer_summary(
-    client: httpx.AsyncClient, base: str
-) -> str | None:
+async def _fetch_pollution_layer_summary(client: httpx.AsyncClient, base: str) -> str | None:
     """Pull the ``Pollution`` layer's ``Summary`` (e.g. ``"4%"``) from worldlayers.
 
     The worldlayers endpoint is public — no admin token needed — which is
@@ -578,16 +598,10 @@ async def fetch_climate(
             # exposes so the empty-state card can hint at why we found
             # nothing, and so future debugging doesn't need server logs.
             climate_kws = (
-                CO2_DISCOVERY_KEYWORDS
-                + SEA_LEVEL_DISCOVERY_KEYWORDS
-                + POLLUTION_DISCOVERY_KEYWORDS
+                CO2_DISCOVERY_KEYWORDS + SEA_LEVEL_DISCOVERY_KEYWORDS + POLLUTION_DISCOVERY_KEYWORDS
             )
             snapshot.available_climate_datasets = sorted(
-                {
-                    name
-                    for name in flatlist
-                    if any(kw in name.lower() for kw in climate_kws)
-                }
+                {name for name in flatlist if any(kw in name.lower() for kw in climate_kws)}
             )
 
             # Polluter attribution. Sequential per-action because the exporter
@@ -717,9 +731,7 @@ def compute_climate_payload(snapshot: ClimateSnapshot) -> dict[str, Any]:
 
     sea_last = _series_last(snapshot.sea_level_series)
     sea_first = _series_first(snapshot.sea_level_series)
-    sea_change_pct = (
-        _percent_change(sea_first, sea_last) if snapshot.sea_level_series else None
-    )
+    sea_change_pct = _percent_change(sea_first, sea_last) if snapshot.sea_level_series else None
     # Linear extrapolation: at the current rate, when does sea level cross +1
     # unit? The mod reads sea level in arbitrary units, so we project the
     # number of cycle-days, not meters — interpretation is the player's job.
@@ -745,9 +757,7 @@ def compute_climate_payload(snapshot: ClimateSnapshot) -> dict[str, Any]:
     earth_match = _earth_year_for_ppm(co2_last) if snapshot.co2_series else None
     status = _classify_status(co2_last, sea_change_pct) if snapshot.co2_series else "unknown"
 
-    has_attribution = bool(
-        snapshot.top_polluter_citizens or snapshot.top_polluter_stations
-    )
+    has_attribution = bool(snapshot.top_polluter_citizens or snapshot.top_polluter_stations)
 
     narrative = _narrative(
         status=status,
@@ -784,9 +794,7 @@ def compute_climate_payload(snapshot: ClimateSnapshot) -> dict[str, Any]:
             "series": [list(p) for p in snapshot.sea_level_series],
         },
         "pollution": {
-            "current": (
-                round(pollution_value, 2) if pollution_value is not None else None
-            ),
+            "current": (round(pollution_value, 2) if pollution_value is not None else None),
             "source": pollution_source,
             "dataset_name": snapshot.pollution_dataset_name,
             "layer_summary": snapshot.pollution_layer_summary,

--- a/src/eco_mcp_app/map.py
+++ b/src/eco_mcp_app/map.py
@@ -267,9 +267,7 @@ def build_map_payload(bundle: dict[str, Any]) -> dict[str, Any]:
     owner_colors = {o: _owner_color(o) for o in owners}
     owner_strokes = {o: _owner_stroke(o) for o in owners}
     pollution_bytes = bundle.get("pollution_gif")
-    pollution_data_uri = (
-        gif_to_data_uri(cast(bytes, pollution_bytes)) if pollution_bytes else None
-    )
+    pollution_data_uri = gif_to_data_uri(cast(bytes, pollution_bytes)) if pollution_bytes else None
     return {
         "view": "eco_map",
         "sourceUrl": bundle.get("base_url"),

--- a/src/eco_mcp_app/server.py
+++ b/src/eco_mcp_app/server.py
@@ -1694,9 +1694,7 @@ def _format_climate_markdown(payload: dict[str, Any]) -> str:
             for entry in attrib.get("top_stations") or []:
                 lines.append(f"- {entry['name']}: {entry['count']:.0f}")
     if not payload["admin_ok"]:
-        lines.extend(
-            ["", "_Admin token unavailable — series + attribution data are empty._"]
-        )
+        lines.extend(["", "_Admin token unavailable — series + attribution data are empty._"])
     return "\n".join(lines)
 
 
@@ -2241,9 +2239,7 @@ def build_server() -> Server:
                 )
             payload = build_map_payload(bundle)
             json_payload = {
-                k: v
-                for k, v in payload.items()
-                if k not in ("gifDataUri", "pollutionDataUri")
+                k: v for k, v in payload.items() if k not in ("gifDataUri", "pollutionDataUri")
             }
             return CallToolResult(
                 content=[

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -92,6 +92,33 @@ def _route_datasets(values: dict[str, list[float]]) -> None:
     respx.get(_DATASET_URL).mock(side_effect=handler)
 
 
+def _parallel_series(values: list[float], unit: str = "PPM") -> dict[str, object]:
+    """Eco 0.13.0.3 parallel-array dataset payload (Times+Values+Interval+Unit).
+
+    Matches the live shape verified against ``eco.coilysiren.me:3001``.
+    """
+    return {
+        "Times": [float(i * 86400) for i, _ in enumerate(values)],
+        "Values": [float(v) for v in values],
+        "Interval": 86400.0,
+        "Unit": unit,
+    }
+
+
+def _route_datasets_parallel(values: dict[str, list[float]]) -> None:
+    """Same as ``_route_datasets`` but returns parallel-arrays shape."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        name = request.url.params.get("dataset", "")
+        if name in values:
+            return httpx.Response(200, json=_parallel_series(values[name]))
+        return httpx.Response(
+            200, json={"Times": [], "Values": [], "Interval": 86400.0, "Unit": "PPM"}
+        )
+
+    respx.get(_DATASET_URL).mock(side_effect=handler)
+
+
 def _route_worldlayers_empty() -> None:
     respx.get(_WORLDLAYERS_URL).mock(return_value=httpx.Response(200, json=[]))
 
@@ -135,6 +162,43 @@ def _route_flatlist_dicts(names: list[str]) -> None:
 # ---------------------------------------------------------------------------
 # fetch_climate
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_fetch_climate_parses_parallel_arrays_shape() -> None:
+    """Eco 0.13.0.3 returns ``{Times,Values,Interval,Unit}`` for ContinuousValue.
+
+    Regression for the empty-card bug: ``_fetch_dataset`` previously only
+    accepted ``list`` payloads and dropped the dict-shape series silently.
+    Verified live against ``http://eco.coilysiren.me:3001/datasets/get``
+    on 2026-05-10.
+    """
+    _route_datasets_parallel(
+        {
+            "TotalCO2": [325.0, 325.0, 410.04, 520.0],
+            "SeaLevel": [60.0, 60.0, 60.13, 61.0],
+            "TotalGroundPollution": [0.0, 16.8, 629.4, 705.9],
+        }
+    )
+    _route_flatlist([])
+    _route_worldlayers_empty()
+    _route_actions_empty()
+
+    snap = await fetch_climate(
+        None,
+        info=_info(),
+        days_elapsed=4,
+        admin_token="test-token",
+        default_admin_base=_DEFAULT_BASE,
+    )
+
+    assert snap.co2_dataset_name == "TotalCO2"
+    assert [v for _, v in snap.co2_series] == [325.0, 325.0, 410.04, 520.0]
+    assert snap.sea_level_dataset_name == "SeaLevel"
+    assert [v for _, v in snap.sea_level_series] == [60.0, 60.0, 60.13, 61.0]
+    assert snap.pollution_dataset_name == "TotalGroundPollution"
+    assert [v for _, v in snap.pollution_series] == [0.0, 16.8, 629.4, 705.9]
 
 
 @pytest.mark.asyncio
@@ -208,9 +272,7 @@ async def test_fetch_climate_aggregates_polluter_attribution() -> None:
     for action in POLLUTION_ACTION_TYPES:
         if action == "PollutionAction":
             continue
-        respx.get(f"{base_actions}?actionName={action}").mock(
-            return_value=httpx.Response(404)
-        )
+        respx.get(f"{base_actions}?actionName={action}").mock(return_value=httpx.Response(404))
 
     snap = await fetch_climate(
         None,
@@ -330,9 +392,7 @@ async def test_fetch_climate_parses_dict_shape_flatlist() -> None:
     assert "TotalCO2" in snap.available_climate_datasets
     assert "SeaLevel" in snap.available_climate_datasets
     assert "TotalGroundPollution" in snap.available_climate_datasets
-    assert not any(
-        "{" in n or "'Name'" in n for n in snap.available_climate_datasets
-    )
+    assert not any("{" in n or "'Name'" in n for n in snap.available_climate_datasets)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #34.

## Root cause

`/datasets/get` on Eco 0.13.0.3 returns parallel arrays for ContinuousValue stats, verified live on 2026-05-10:

    GET http://eco.coilysiren.me:3001/datasets/get?dataset=TotalCO2&dayStart=0&dayEnd=24
    {"Times":[0,86400,...], "Values":[325.0,...,410.04,520.0], "Interval":86400.0, "Unit":"PPM"}

`_fetch_dataset` only handled `isinstance(data, list)` and dropped the dict shape on the floor, so #31/#32/#33 each rendered an empty card despite the data being there.

## Fix

- New `_parse_parallel_arrays` zips `Times` + `Values` into `[(t, v), ...]`.
- `_fetch_dataset` calls it on `isinstance(data, dict)`.
- New respx test `test_fetch_climate_parses_parallel_arrays_shape` pins the live shape for `TotalCO2`, `SeaLevel`, `TotalGroundPollution`.

## Drive-by

- Ruff format pass on `map.py` / `server.py` (CI was failing on format check).
- Dropped a stale quoted forward-ref on `_climate_cache: TTLCache[str, ClimateSnapshot]` now that `from __future__ import annotations` defers resolution.

## Out of scope

`tests/test_map.py` has 3 pre-existing failures (Pollution.gif mock gap from #31) unrelated to this change.

## Test plan

- [x] `coily exec test` - 225 passed locally (3 pre-existing map failures unchanged)
- [x] `coily exec ruff` - clean
- [ ] CI green
- [ ] Post-deploy: `get_eco_climate` against live server renders non-zero CO2 / sea-level / ground-pollution